### PR TITLE
👷 Add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:cov": "istanbul cover ./node_modules/mocha/bin/_mocha -- ./tests/** --recursive --report lcov --compilers js:babel-register",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
+    "prepare": "npm run clean && npm run build",
     "preversion": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Added `prepare` script to build lib when the package is installed. 

I noticed there's also a `preversion` script which only runs when bumping the package version. Was `preversion` suppose to be `prepare`? Shall I remove `preversion`? Let me know.

More info on `npm` scripts:
https://docs.npmjs.com/misc/scripts

*Note: I think `prepare` only works with npm v4+, if we want to support npm < 4 we should use `prepublish`.*

Related to #1, #3.