### PR TITLE
v0.1.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,76 @@ export default connect((state) => ({
   todos: state.firestore.ordered.todos
 }))(Todos)
 ```
+#### Types of Query Options
+
+##### get
+```js
+props.store.firestore.get({ collection: 'cities' }),
+// store.firestore.get({ collection: 'cities', doc: 'SF' }), // doc
+```
+
+##### onSnapshot/setListener
+
+```js
+store.firestore.onSnapshot({ collection: 'cities' }),
+// store.firestore.setListener({ collection: 'cities' }), // alias
+// store.firestore.setListener({ collection: 'cities', doc: 'SF' }), // doc
+```
+
+#### setListeners
+
+```js
+store.firestore.setListeners([
+  { collection: 'cities' },
+  { collection: 'users' },
+]),
+```
+
+#### Query Options
+
+##### Collection
+```js
+{ collection: 'cities' },
+// or string equivalent
+// store.firestore.get('cities'),
+```
+
+##### Document
+
+```js
+{ collection: 'cities', doc: 'SF' },
+// or string equivalent
+// props.store.firestore.get('cities/SF'),
+```
+
+##### Where
+
+**Single**
+To create a single where call, pass a single argument array to where
+
+```js
+{
+  collection: 'cities',
+  where: ['state', '==', 'CA']
+},
+```
+
+**Multiple**
+
+Multiple where queries are as simple as passing mutiple argument arrays (each one representing a where call)
+
+```js
+{
+  collection: 'cities',
+  where: [
+    ['state', '==', 'CA'],
+    ['population', '<', 100000],
+    ['name', '>=', 'San Francisco']
+  ]
+},
+```
+
+*Should only be used with collections*
 
 <!-- #### Middleware
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ export default connect((state) => ({
   todos: state.firestore.ordered.todos
 }))(Todos)
 ```
-#### Types of Query Options
+
+#### Types of Queries
 
 ##### get
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,12 @@ export const constants: {
 export function reduxFirestore(firebaseInstance: object, otherConfig: object): any;
 
 /**
+ * Get extended firestore instance (attached to store.firestore)
+ */
+export function getFirestore(firebaseInstance: object, otherConfig: object): any;
+
+
+/**
  * A redux store reducer for Firestore state
  */
 export namespace firestoreReducer {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.1.0-alpha",
+  "version": "0.1.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-beta",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -150,7 +150,7 @@ export const deleteRef = (firebase, dispatch, queryOption) => {
  * @param  {Function} errorCb - Callback called on error
  */
 export const setListener = (firebase, dispatch, queryOpts, successCb, errorCb) => {
-  const meta = getQueryConfigs(queryOpts);
+  const meta = getQueryConfig(queryOpts);
   const {
     collection,
     doc,
@@ -172,7 +172,7 @@ export const setListener = (firebase, dispatch, queryOpts, successCb, errorCb) =
     }, (err) => {
       // TODO: Look into whether listener is automatically removed in all cases
       dispatch({
-        type: actionTypes.ON_SNAPSHOT_ERROR,
+        type: actionTypes.LISTENER_ERROR,
         meta,
         payload: err,
       });
@@ -228,7 +228,6 @@ export default {
   firestoreRef,
   add,
   update,
-  onSnapshot,
   setListener,
   setListeners,
   unsetListener,

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -68,11 +68,11 @@ export const set = (firebase, dispatch, queryOption, ...args) => {
  * @return {Promise} Resolves with results of get call
  */
 export const get = (firebase, dispatch, queryOption) => {
-  const { collection, doc } = getQueryConfig(queryOption);
+  const meta = getQueryConfig(queryOption);
   return wrapInDispatch(dispatch, {
-    ref: firestoreRef(firebase, dispatch, { collection, doc }),
+    ref: firestoreRef(firebase, dispatch, meta),
     method: 'get',
-    meta: { collection, doc },
+    meta,
     types: [
       actionTypes.GET_REQUEST,
       {
@@ -144,16 +144,23 @@ export const deleteRef = (firebase, dispatch, queryOption) => {
  * @param {Object} meta - Metadata
  * @param {String} meta.collection - Collection name
  * @param {String} meta.doc - Document name
+ * @param {Array} meta.where - Where settings for query. Array of strings
+ * for one where, an Array of Arrays for multiple wheres
  * @param  {Function} successCb - Callback called on success
  * @param  {Function} errorCb - Callback called on error
  */
-export const onSnapshot = (firebase, dispatch, { collection, doc }, successCb, errorCb) => {
-  const query = firebase.firestore().collection(collection);
-  const unsubscribe = doc ? query.doc(doc) : query
+export const setListener = (firebase, dispatch, queryOpts, successCb, errorCb) => {
+  const meta = getQueryConfigs(queryOpts);
+  const {
+    collection,
+    doc,
+    // subCollections,
+  } = meta;
+  const unsubscribe = firestoreRef(firebase, dispatch, meta)
     .onSnapshot((docData) => {
       dispatch({
         type: actionTypes.LISTENER_RESPONSE,
-        meta: { collection, doc },
+        meta,
         payload: {
           data: dataByIdSnapshot(docData),
           ordered: orderedFromSnap(docData),
@@ -163,54 +170,15 @@ export const onSnapshot = (firebase, dispatch, { collection, doc }, successCb, e
         successCb(docData);
       }
     }, (err) => {
-      // TODO: Look into whether unsubscribe should automatically be called or not
+      // TODO: Look into whether listener is automatically removed in all cases
       dispatch({
         type: actionTypes.ON_SNAPSHOT_ERROR,
-        meta: { collection, doc },
+        meta,
         payload: err,
       });
       if (errorCb) {
         errorCb(err);
       }
-    });
-  attachListener(firebase, dispatch, { collection, doc }, unsubscribe);
-};
-
-/**
- * Set listener to Cloud Firestore. Internall calls Firebase's onSnapshot()
- * method.
- * @param {Object} firebase - Internal firebase object
- * @param {Function} dispatch - Redux's dispatch function
- * @param {Object} meta - Metadata
- * @param {String} meta.collection - Collection name
- * @param {String} meta.doc - Document name
- * @return {Promise} Resolves when listener has been attached **not** when data
- * has been gathered by the listener.
- */
-export const setListener = (firebase, dispatch, queryOpts) => {
-  const {
-    collection,
-    doc,
-    // subCollection,
-    // other,
-  } = getQueryConfigs(queryOpts);
-  const unsubscribe = firestoreRef(firebase, dispatch, { collection, doc })
-    .onSnapshot((docData) => {
-      dispatch({
-        type: actionTypes.LISTENER_RESPONSE,
-        meta: { collection, doc },
-        payload: {
-          data: dataByIdSnapshot(docData),
-          ordered: orderedFromSnap(docData),
-        },
-      });
-    }, (err) => {
-      // TODO: Look into whether listener is automatically removed in all cases
-      dispatch({
-        type: actionTypes.ON_SNAPSHOT_ERROR,
-        meta: { collection, doc },
-        payload: err,
-      });
     });
   attachListener(firebase, dispatch, { collection, doc }, unsubscribe);
 };

--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -14,6 +14,7 @@ const createFirestoreInstance = (firebase, configs, dispatch) => {
 
   const aliases = [
     { action: firestoreActions.deleteRef, name: 'delete' },
+    { action: firestoreActions.setListener, name: 'onSnapshot' },
   ];
 
   // support extending existing firebase internals (using redux-firestore along with redux-firebase)

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,6 +1,8 @@
 import { defaultConfig } from './constants';
 import createFirestoreInstance from './createFirestoreInstance';
 
+let firestoreInstance;
+
 /**
  * @name reduxFirestore
  * @external
@@ -58,3 +60,47 @@ export default (firebaseInstance, otherConfig) => next =>
 
     return store;
   };
+
+/**
+ * @description Expose Firestore instance created internally. Useful for
+ * integrations into external libraries such as redux-thunk and redux-observable.
+ * @example <caption>redux-thunk integration</caption>
+ * import { applyMiddleware, compose, createStore } from 'redux';
+ * import thunk from 'redux-thunk';
+ * import makeRootReducer from './reducers';
+ * import { reduxFirestore, getFirestore } from 'redux-firestore';
+ *
+ * const fbConfig = {} // your firebase config
+ *
+ * const store = createStore(
+ *   makeRootReducer(),
+ *   initialState,
+ *   compose(
+ *     applyMiddleware([
+ *       // Pass getFirestore function as extra argument
+ *       thunk.withExtraArgument(getFirestore)
+ *     ]),
+ *     reduxFirestore(fbConfig)
+ *   )
+ * );
+ * // then later
+ * export const addTodo = (newTodo) =>
+ *  (dispatch, getState, getFirestore) => {
+ *    const firebase = getFirestore()
+ *    firebase
+ *      .add('todos', newTodo)
+ *      .then(() => {
+ *        dispatch({ type: 'SOME_ACTION' })
+ *      })
+ * };
+ *
+ */
+export const getFirestore = () => {
+    // TODO: Handle recieveing config and creating firebase instance if it doesn't exist
+    /* istanbul ignore next: Firebase instance always exists during tests */
+  if (!firestoreInstance) {
+    throw new Error('Firebase instance does not yet exist. Check your compose function.'); // eslint-disable-line no-console
+  }
+    // TODO: Create new firebase here with config passed in
+  return firestoreInstance;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import enhancer from './enhancer';
+import enhancer, { getFirestore } from './enhancer';
 import reducer from './reducer';
 import { firestoreActions } from './actions';
 import createFirestoreInstance from './createFirestoreInstance';
@@ -12,6 +12,7 @@ export default {
   actions: firestoreActions,
   reducer,
   enhancer,
+  getFirestore,
   constants,
   actionTypes,
   middleware,

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -24,8 +24,8 @@ export const firestoreRef = (firebase, dispatch, meta) => {
     if (!isArray(where)) {
       throw new Error('where parameter must be an array');
     }
-    if (where.length === 1) {
-      ref = ref.where(...where);
+    if (isString(where[0])) {
+      ref = where.length > 1 ? ref.where(...where) : ref.where(where[0]);
     } else {
       forEach(where, (whereArgs) => {
         if (!isArray(whereArgs)) {
@@ -33,11 +33,31 @@ export const firestoreRef = (firebase, dispatch, meta) => {
             'Where currently only supports arrays. Each option must be an Array of arguments to pass to where.',
           );
         }
-        ref = ref.where(...whereArgs);
+        ref = whereArgs.length > 1 ? ref.where(...whereArgs) : ref.where(whereArgs);
       });
     }
   }
   return ref;
+};
+
+const whereToStr = where =>
+  isString(where[0]) ? where.join(':') : where.map(whereToStr);
+
+const getQueryName = (meta) => {
+  const { collection, doc, where } = meta;
+  if (!collection) {
+    throw new Error('Collection is required to build query name');
+  }
+  if (doc) {
+    return `${collection}/${doc}`;
+  }
+  if (where) {
+    if (!isArray(where)) {
+      throw new Error('Where must be an array');
+    }
+    return `${collection}/${doc}/${whereToStr(where)}`;
+  }
+  return collection;
 };
 
 
@@ -50,8 +70,8 @@ export const firestoreRef = (firebase, dispatch, meta) => {
  * @param {String} doc - Document name
  * @return {Object} Object containing all listeners
  */
-export const attachListener = (firebase, dispatch, { collection, doc }, unsubscribe) => {
-  const name = doc ? `${collection}/${doc}` : collection;
+export const attachListener = (firebase, dispatch, meta, unsubscribe) => {
+  const name = getQueryName(meta);
   if (!firebase._.listeners[name]) {
     firebase._.listeners[name] = unsubscribe; // eslint-disable-line no-param-reassign
   } else {
@@ -60,7 +80,7 @@ export const attachListener = (firebase, dispatch, { collection, doc }, unsubscr
 
   dispatch({
     type: actionTypes.SET_LISTENER,
-    meta: { collection, doc },
+    meta,
     payload: { name },
   });
 
@@ -75,8 +95,8 @@ export const attachListener = (firebase, dispatch, { collection, doc }, unsubscr
  * @param {String} collection - Collection name
  * @param {String} doc - Document name
  */
-export const detachListener = (firebase, dispatch, { collection, doc }) => {
-  const name = doc ? `${collection}/${doc}` : collection;
+export const detachListener = (firebase, dispatch, meta) => {
+  const name = getQueryName(meta);
   if (firebase._.listeners[name]) {
     firebase._.listeners[name]();
   } else {
@@ -85,7 +105,7 @@ export const detachListener = (firebase, dispatch, { collection, doc }) => {
 
   dispatch({
     type: actionTypes.UNSET_LISTENER,
-    meta: { collection, doc },
+    meta,
     payload: { name },
   });
 };


### PR DESCRIPTION
* feat(query): `where` support in queries (single Array or Array of Arrays)
* feat(query): `onSnapshot` is now an alias of `setListener`  instead of being its own function
* fix(query): correctly dispatching `LISTENER_ERROR` action type on query listener errors
* feat(query): query name within reducers includes `where`
* feat(core): `getFirestore` added to get internal `store.firestore` instance - #13
* feat(typings): `getFirestore` added to typscript typings
* feat(docs): README updated with Query options