### PR TITLE
Fix attaching and detaching listeners

### DIFF
--- a/src/reducers/listenersReducer.js
+++ b/src/reducers/listenersReducer.js
@@ -16,13 +16,13 @@ const listenersById = (state = {}, { type, path, payload }) => {
     case actionTypes.SET_LISTENER:
       return {
         ...state,
-        [payload.id]: {
-          id: payload.id,
+        [payload.name]: {
+          name: payload.name,
           path,
         },
       };
     case actionTypes.UNSET_LISTENER:
-      return omit(state, [payload.id]);
+      return omit(state, [payload.name]);
     default: return state;
   }
 };
@@ -39,9 +39,9 @@ const listenersById = (state = {}, { type, path, payload }) => {
 const allListeners = (state = [], { type, payload }) => {
   switch (type) {
     case actionTypes.SET_LISTENER:
-      return [...state, payload.id];
+      return [...state, payload.name];
     case actionTypes.UNSET_LISTENER:
-      return state.filter(lId => lId !== payload.id);
+      return state.filter(name => name !== payload.name);
     default: return state;
   }
 };

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -99,6 +99,7 @@ export const detachListener = (firebase, dispatch, meta) => {
   const name = getQueryName(meta);
   if (firebase._.listeners[name]) {
     firebase._.listeners[name]();
+    delete firebase._.listeners[name]; // eslint-disable-line no-param-reassign
   } else {
     console.warn(`Listener does not exist for ${name}`); // eslint-disable-line no-console
   }


### PR DESCRIPTION
Prior to this change, the `listenersReducer` is reading the `payload.id` while the action is dispatched with `name` property instead.

On top of that, while detaching listeners, the listener is not deleted, resulting in a warning of `Listener already exists`.