### PR TITLE
v0.1.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -6,7 +6,6 @@ import {
   detachListener,
   orderedFromSnap,
   dataByIdSnapshot,
-  getQueryConfigs,
   getQueryConfig,
   firestoreRef,
 } from '../utils/query';
@@ -208,7 +207,7 @@ export const setListeners = (firebase, dispatch, listeners) => {
  * has been gathered by the listener.
  */
 export const unsetListener = (firebase, dispatch, opts) =>
-  detachListener(firebase, dispatch, getQueryConfigs(opts));
+  detachListener(firebase, dispatch, getQueryConfig(opts));
 
 /**
  * Unset a list of listeners

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -1,60 +1,19 @@
-import { pick } from 'lodash';
+import { pick, assign, get } from 'lodash';
 import { setWith } from 'lodash/fp';
 import { actionTypes } from '../constants';
 
 const { CLEAR_DATA, GET_SUCCESS, LISTENER_RESPONSE } = actionTypes;
 
 const pathFromMeta = ({ collection, doc, subcollections }) => {
-  const basePath = `${collection}.${doc}`;
+  const basePath = collection;
+  if (doc) {
+    basePath.concat(doc);
+  }
   if (!subcollections) {
     return basePath;
   }
   const mappedCollections = subcollections.map(pathFromMeta);
   return basePath.concat(mappedCollections.join('.'));
-};
-
-/**
- * Creates reducer for data state. Used to create data and ordered reducers.
- * Changed by `SET` or `SET_ORDERED` (if actionKey === 'ordered'), `MERGE`,
- * `NO_VALUE`, and `LOGOUT` actions.
- * @param  {Object} [state={}] - Current data redux state
- * @param  {Object} action - Object containing the action that was dispatched
- * @param  {String} action.type - Type of action that was dispatched
- * @param  {String} action.path - Path of action that was dispatched
- * @return {Object} Data state after reduction
- * @private
- */
-export const createDataReducer = (actionKey = 'data') => (state = {}, action) => {
-  switch (action.type) {
-    case GET_SUCCESS:
-    case LISTENER_RESPONSE:
-      if (!action.payload || action.payload[actionKey] === undefined) {
-        return state;
-      }
-      if (action.meta.doc) {
-        return setWith(Object, pathFromMeta(action.meta), action.payload[actionKey], state);
-      }
-      if (action.merge) {
-        return {
-          ...state,
-          [action.meta.collection]: state[action.meta.collection]
-            ? { ...state[action.meta.collection], ...action.payload[actionKey] }
-            : action.payload[actionKey],
-        };
-      }
-      return {
-        ...state,
-        [action.meta.collection]: action.payload[actionKey],
-      };
-    case CLEAR_DATA:
-      // support keeping data when logging out - #125
-      if (action.preserve) {
-        return pick(state, action.preserve); // pick returns a new object
-      }
-      return actionKey === 'ordered' ? [] : {};
-    default:
-      return state;
-  }
 };
 
 /**
@@ -67,5 +26,34 @@ export const createDataReducer = (actionKey = 'data') => (state = {}, action) =>
  * @param  {String} action.path - Path of action that was dispatched
  * @return {Object} Data state after reduction
  */
-
-export default createDataReducer();
+export default function dataReducer(state = {}, action) {
+  switch (action.type) {
+    case GET_SUCCESS:
+    case LISTENER_RESPONSE:
+      if (!action.payload || action.payload.data === undefined) {
+        return state;
+      }
+      if (action.merge) {
+        return {
+          ...state,
+          [action.meta.collection]: state[action.meta.collection]
+            ? { ...state[action.meta.collection], ...action.payload.data }
+            : action.payload.data,
+        };
+      }
+      const previousData = get(state, pathFromMeta(action.meta));
+      if (!previousData) {
+        return setWith(Object, pathFromMeta(action.meta), action.payload.data, state);
+      }
+      const mergedData = assign(previousData, action.payload.data);
+      return setWith(Object, pathFromMeta(action.meta), mergedData, state);
+    case CLEAR_DATA:
+      // support keeping data when logging out - #125
+      if (action.preserve) {
+        return pick(state, action.preserve); // pick returns a new object
+      }
+      return {};
+    default:
+      return state;
+  }
+}

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -5,15 +5,15 @@ import { actionTypes } from '../constants';
 const { CLEAR_DATA, GET_SUCCESS, LISTENER_RESPONSE } = actionTypes;
 
 const pathFromMeta = ({ collection, doc, subcollections }) => {
-  const basePath = collection;
+  let basePath = collection;
   if (doc) {
-    basePath.concat(doc);
+    basePath += `.${doc}`;
   }
   if (!subcollections) {
     return basePath;
   }
   const mappedCollections = subcollections.map(pathFromMeta);
-  return basePath.concat(mappedCollections.join('.'));
+  return basePath.concat(`.${mappedCollections.join('.')}`);
 };
 
 /**

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -11,7 +11,7 @@ const { GET_SUCCESS, LISTENER_RESPONSE, CLEAR_DATA } = actionTypes;
  * @param  {String} action.path - Path of action that was dispatched
  * @return {Object} Data state after reduction
  */
-const orderedReducer = (state = {}, action) => {
+export default function orderedReducer(state = {}, action) {
   switch (action.type) {
     case GET_SUCCESS:
     case LISTENER_RESPONSE:
@@ -32,6 +32,4 @@ const orderedReducer = (state = {}, action) => {
     default:
       return state;
   }
-};
-
-export default orderedReducer;
+}

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -1,7 +1,29 @@
-import { pick } from 'lodash';
+import { pick, get, first } from 'lodash';
 import { actionTypes } from '../constants';
 
 const { GET_SUCCESS, LISTENER_RESPONSE, CLEAR_DATA } = actionTypes;
+
+function updateObject(oldObject, newValues) {
+    // Encapsulate the idea of passing a new object as the first parameter
+    // to Object.assign to ensure we correctly copy data instead of mutating
+  return Object.assign({}, oldObject, newValues);
+}
+
+function updateItemInArray(array, itemId, updateItemCallback) {
+  const updatedItems = array.map((item) => {
+    if (item.id !== itemId) {
+            // Since we only want to update one item, preserve all others as they are now
+      return item;
+    }
+
+        // Use the provided callback to create an updated item
+    const updatedItem = updateItemCallback(item);
+    return updatedItem;
+  });
+
+  return updatedItems;
+}
+
 
 /**
  * Reducer for ordered state.
@@ -19,6 +41,19 @@ export default function orderedReducer(state = {}, action) {
         return state;
       }
       // TODO: Support merging
+      if (action.meta.doc) {
+        const itemToAdd = first(action.payload.ordered);
+        const subcollection = first(action.meta.subcollections);
+        // TODO: Make this recursive so that is supports multiple subcollections
+        return {
+          ...state,
+          [action.meta.collection]: updateItemInArray(
+            state[action.meta.collection] || [],
+            action.meta.doc,
+            item => updateObject(item, subcollection ? { [get(subcollection, 'collection')]: action.payload.ordered } : itemToAdd),
+          ),
+        };
+      }
       return {
         ...state,
         [action.meta.collection]: action.payload.ordered,

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,6 +1,26 @@
 import { isObject, isString, isArray, size, trim, forEach } from 'lodash';
 import { actionTypes } from '../constants';
 
+const addWhereToRef = (ref, where) => {
+  let newRef;
+  if (!isArray(where)) {
+    throw new Error('where parameter must be an array');
+  }
+  if (isString(where[0])) {
+    newRef = where.length > 1 ? ref.where(...where) : ref.where(where[0]);
+  } else {
+    forEach(where, (whereArgs) => {
+      if (!isArray(whereArgs)) {
+        throw new Error(
+          'Where currently only supports arrays. Each option must be an Array of arguments to pass to where.',
+        );
+      }
+      newRef = whereArgs.length > 1 ? ref.where(...whereArgs) : ref.where(whereArgs);
+    });
+  }
+  return newRef;
+};
+
 /**
  * Create a Cloud Firestore reference for a collection or document
  * @param {Object} firebase - Internal firebase object
@@ -23,29 +43,18 @@ export const firestoreRef = (firebase, dispatch, meta) => {
   if (subcollections) {
     forEach(subcollections, (subcollection) => {
       if (subcollection.collection) {
-        ref.collection(subcollection.collection);
+        ref = ref.collection(subcollection.collection);
       }
       if (subcollection.doc) {
-        ref.doc(subcollection.doc);
+        ref = ref.doc(subcollection.doc);
+      }
+      if (subcollection.where) {
+        ref = addWhereToRef(ref, subcollection.where);
       }
     });
   }
   if (where) {
-    if (!isArray(where)) {
-      throw new Error('where parameter must be an array');
-    }
-    if (isString(where[0])) {
-      ref = where.length > 1 ? ref.where(...where) : ref.where(where[0]);
-    } else {
-      forEach(where, (whereArgs) => {
-        if (!isArray(whereArgs)) {
-          throw new Error(
-            'Where currently only supports arrays. Each option must be an Array of arguments to pass to where.',
-          );
-        }
-        ref = whereArgs.length > 1 ? ref.where(...whereArgs) : ref.where(whereArgs);
-      });
-    }
+    ref = addWhereToRef(ref, where);
   }
   return ref;
 };


### PR DESCRIPTION
* fix(listeners): `unsetListener` works all the time (instead of just when array config is passed)
* feat(reducers): `dataReducer` now supports merging data (useful if another query has written data to that same redux path)
* feat(reducer): `orderedReducer` includes logic to work with subcollections - #7