### PR TITLE
Fix getQueryName to return string with doc and subcollections info

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -117,15 +117,15 @@ const getQueryName = (meta) => {
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }
-  const basePath = collection;
+  let basePath = collection;
   if (doc) {
-    basePath.concat(`/${doc}`);
+    basePath = basePath.concat(`/${doc}`);
   }
   if (subcollections) {
     const mappedCollections = subcollections.map(subcollection =>
       subcollection.collection.concat(subcollection.doc ? `/${subcollection.doc}` : ''),
     );
-    basePath.concat(mappedCollections.join('/'));
+    basePath = basePath.concat(mappedCollections.join('/'));
   }
   if (where) {
     if (!isArray(where)) {


### PR DESCRIPTION
Turns out the `basePath.concat` calls weren't assigned to the same variable again to be returned later.