### PR TITLE
v0.2.3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,8 @@
     "lodash",
     "add-module-exports",
     "transform-object-rest-spread",
-    "transform-object-assign"
+    "transform-object-assign",
+    "transform-inline-environment-variables"
   ],
   "env": {
     "es": {

--- a/.babelrc
+++ b/.babelrc
@@ -12,17 +12,20 @@
     "lodash",
     "add-module-exports",
     "transform-object-rest-spread",
-    "transform-object-assign",
-    "transform-inline-environment-variables"
+    "transform-object-assign"
   ],
   "env": {
     "es": {
       "comments": false,
-      "minified": false
+      "plugins": [
+        "transform-inline-environment-variables"
+      ]
     },
     "commonjs": {
       "comments": false,
-      "minified": false
+      "plugins": [
+        "transform-inline-environment-variables"
+      ]
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -10,16 +10,21 @@
   ],
   "plugins": [
     "lodash",
-    "transform-inline-environment-variables",
     "transform-object-rest-spread",
     "transform-object-assign",
   ],
   "env": {
     "es": {
-      "comments": false
+      "comments": false,
+      "plugins": [
+        "transform-inline-environment-variables"
+      ]
     },
     "commonjs": {
-      "comments": false
+      "comments": false,
+      "plugins": [
+        "transform-inline-environment-variables"
+      ]
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -10,22 +10,16 @@
   ],
   "plugins": [
     "lodash",
-    "add-module-exports",
+    "transform-inline-environment-variables",
     "transform-object-rest-spread",
-    "transform-object-assign"
+    "transform-object-assign",
   ],
   "env": {
     "es": {
-      "comments": false,
-      "plugins": [
-        "transform-inline-environment-variables"
-      ]
+      "comments": false
     },
     "commonjs": {
-      "comments": false,
-      "plugins": [
-        "transform-inline-environment-variables"
-      ]
+      "comments": false
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -374,8 +374,10 @@ Note: In an effort to keep things simple, the wording from this explanation was 
 
 ## Roadmap
 
+* Automatic support for documents that have a parameter and a subcollection with the same name (currently requires `storeAs`)
 * Support for Passing a Ref to `setListener` in place of `queryConfig` object or string
 
+Post an issue with a feature suggestion if you have any ideas!
 
 [npm-image]: https://img.shields.io/npm/v/redux-firestore.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/redux-firestore

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,12 +802,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-add-module-exports": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
-      "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
-      "dev": true
-    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
@@ -1190,6 +1184,12 @@
         "babel-plugin-syntax-flow": "6.18.0",
         "babel-runtime": "6.26.0"
       }
+    },
+    "babel-plugin-transform-inline-environment-variables": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.2.0.tgz",
+      "integrity": "sha512-vh52tYTkqK1jEYOJPBGscWzs43NRUIlzZ5UcO2FiWZlsXs1pp/gmVXtcbd5yseXbEPUXUszMYVLI+E7joBhnXw==",
+      "dev": true
     },
     "babel-plugin-transform-object-assign": {
       "version": "6.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "babel-loader": "^7.1.2",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-inline-environment-variables": "^0.2.0",
     "babel-plugin-transform-object-assign": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-transform-inline-environment-variables": "^0.2.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,9 @@ import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
 
 // converted with transform-inline-environment-variables
-const version = process.env.npm_package_version;
+export const version = process.env.npm_package_version;
 
 export {
-  version,
   reducer,
   reducer as firestoreReducer,
   enhancer,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
 
 export default {
+  version: process.env.npm_package_version, // converted with transform-inline-environment-variables
   firestoreReducer: reducer,
   reduxFirestore: enhancer,
   createFirestoreInstance,

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,32 @@ import createFirestoreInstance from './createFirestoreInstance';
 import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
 
+// converted with transform-inline-environment-variables
+const version = process.env.npm_package_version;
+
+export {
+  version,
+  reducer,
+  reducer as firestoreReducer,
+  enhancer,
+  enhancer as reduxFirestore,
+  createFirestoreInstance,
+  firestoreActions as actions,
+  getFirestore,
+  constants,
+  actionTypes,
+  middleware,
+  CALL_FIRESTORE,
+};
+
 export default {
-  version: process.env.npm_package_version, // converted with transform-inline-environment-variables
+  version,
+  reducer,
   firestoreReducer: reducer,
+  enhancer,
   reduxFirestore: enhancer,
   createFirestoreInstance,
   actions: firestoreActions,
-  reducer,
-  enhancer,
   getFirestore,
   constants,
   actionTypes,

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -23,7 +23,7 @@ export default function dataReducer(state = {}, action) {
   switch (action.type) {
     case GET_SUCCESS:
     case LISTENER_RESPONSE:
-      const { meta, payload, preserve } = action;
+      const { meta, payload } = action;
       // Return state if payload are invalid
       if (!payload || payload.data === undefined) {
         return state;
@@ -47,8 +47,8 @@ export default function dataReducer(state = {}, action) {
       return setWith(Object, pathFromMeta(meta), mergedData, state);
     case CLEAR_DATA:
       // support keeping data when logging out - #125 of react-redux-firebase
-      if (preserve) {
-        return pick(state, preserve); // pick returns a new object
+      if (action.preserve) {
+        return pick(state, action.preserve); // pick returns a new object
       }
       return {};
     default:

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -51,17 +51,9 @@ export const combineReducers = reducers =>
       {},
     );
 
-export const getFirestorePath = (action) => {
-  if (!action.meta) {
-    throw new Error('Meta is required to create firestore path');
-  }
-  const { meta: { collection, doc } } = action;
-  return doc ? `${collection}/${doc}` : collection;
-};
-
-
 /**
- * Get path from meta data
+ * Get path from meta data. Path is used with lodash's setWith to set deep
+ * data within reducers.
  * @param  {Object} meta - Action meta data object
  * @param  {String} meta.collection - Name of Collection for which the action
  * is to be handled.
@@ -74,6 +66,9 @@ export const getFirestorePath = (action) => {
  * @return {String} String path to be used within reducer
  */
 export function pathFromMeta(meta) {
+  if (!meta) {
+    throw new Error('Action meta is required to build path for reducers');
+  }
   const { collection, doc, subcollections, storeAs } = meta;
   let basePath = collection;
   if (storeAs) {

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -67,13 +67,16 @@ export const combineReducers = reducers =>
  */
 export function pathFromMeta(meta) {
   if (!meta) {
-    throw new Error('Action meta is required to build path for reducers');
+    throw new Error('Action meta is required to build path for reducers.');
   }
   const { collection, doc, subcollections, storeAs } = meta;
-  let basePath = collection;
   if (storeAs) {
     return storeAs;
   }
+  if (!collection) {
+    throw new Error('Collection is required to construct reducer path.');
+  }
+  let basePath = collection;
   if (doc) {
     basePath += `.${doc}`;
   }

--- a/tests/unit/actions/firestore.spec.js
+++ b/tests/unit/actions/firestore.spec.js
@@ -9,13 +9,100 @@ describe('firestoreActions', () => {
   });
 
   describe('actions', () => {
-    it('add', () => {
-      const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
-      try {
-        instance.test.add({ collection: 'test' });
-      } catch (err) {
-        expect(err.message).to.equal('Firestore must be required and initalized.');
-      }
+    describe('add', () => {
+      it('throws if Firestore is not initialized', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.add({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Firestore must be required and initalized.');
+        }
+      });
+    });
+
+    describe('set', () => {
+      it('throws if Firestore is not initialized', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.set({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Firestore must be required and initalized.');
+        }
+      });
+    });
+
+    describe('update', () => {
+      it('throws if Firestore is not initialized', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.update({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Firestore must be required and initalized.');
+        }
+      });
+    });
+
+    describe('deleteRef', () => {
+      it('throws if attempting to delete a collection', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.deleteRef({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Only docs can be deleted');
+        }
+      });
+    });
+
+    describe('setListener', () => {
+      it('throws if Firestore is not initialized', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.setListener({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Firestore must be required and initalized.');
+        }
+      });
+    });
+
+    describe('setListeners', () => {
+      it('throws if listeners config is not an array', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.setListeners({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
+        }
+      });
+    });
+
+    describe('unsetListener', () => {
+      it('throws if invalid path config is provided', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.unsetListener();
+        } catch (err) {
+          expect(err.message).to.equal('Invalid Path Definition: Only Strings and Objects are accepted.');
+        }
+      });
+      it('throws if dispatch is not a function', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.unsetListener({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('dispatch is not a function');
+        }
+      });
+    });
+
+    describe('unsetListeners', () => {
+      it('throws if listeners config is not an array', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.unsetListeners({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
+        }
+      });
     });
   });
 });

--- a/tests/unit/enhancer.spec.js
+++ b/tests/unit/enhancer.spec.js
@@ -1,5 +1,5 @@
 import { createStore, compose } from 'redux';
-import reduxFirestore from '../../src/enhancer';
+import reduxFirestore, { getFirestore } from '../../src/enhancer';
 
 const reducer = sinon.spy();
 const generateCreateStore = () =>
@@ -16,10 +16,18 @@ describe('enhancer', () => {
   it('exports a function', () => {
     expect(reduxFirestore).to.be.a('function');
   });
+
   it('adds firestore to store', () => {
     expect(store).to.have.property('firestore');
   });
+
   it('has the right methods', () => {
     expect(store.firestore.setListener).to.be.a('function');
+  });
+});
+
+describe('getFirestore', () => {
+  it('returns firestore instance created by enhancer', () => {
+    expect(getFirestore()).to.be.an('object');
   });
 });

--- a/tests/unit/reducers/dataReducer.spec.js
+++ b/tests/unit/reducers/dataReducer.spec.js
@@ -1,4 +1,12 @@
 import dataReducer from '../../../src/reducers/dataReducer';
+import { actionTypes } from '../../../src/constants';
+
+const state = {};
+const collection = 'test';
+
+let action = {};
+let payload = {};
+let meta = {};
 
 describe('dataReducer', () => {
   it('is exported', () => {
@@ -7,7 +15,134 @@ describe('dataReducer', () => {
   it('is a function', () => {
     expect(dataReducer).to.be.a('function');
   });
+
   it('returns state for undefined actionType', () => {
     expect(dataReducer({}, {})).to.be.empty;
+  });
+
+  describe('actionTypes', () => {
+    describe('LISTENER_RESPONSE', () => {
+      it('returns state if payload is not defined', () => {
+        action = { meta: 'test', type: actionTypes.LISTENER_RESPONSE };
+        expect(dataReducer(state, action)).to.equal(state);
+      });
+
+      it('returns state if payload does not contain data', () => {
+        payload = {};
+        action = { meta: {}, payload, type: actionTypes.LISTENER_RESPONSE };
+        expect(dataReducer(state, action)).to.equal(state);
+      });
+
+      it('updates collection', () => {
+        payload = { data: { abc: { field: 'test' } } };
+        meta = { collection };
+        action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+        expect(dataReducer(state, action).test.abc.field).to.equal('test');
+      });
+
+      it('throws for no collection', () => {
+        payload = { data: { abc: {} } };
+        meta = {};
+        action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+        expect(() => dataReducer(state, action))
+          .to.throw('Collection is required to construct reducer path.');
+      });
+
+      describe('with subcollections parameter', () => {
+        it('updates empty state', () => {
+          const data = { abc: { field: 'test' } };
+          payload = { data };
+          meta = { collection, doc: 'someDoc', subcollections: [{ collection: 'another' }] };
+          action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+          expect(dataReducer(state, action))
+            .to.have.nested.property('test.someDoc.another', data);
+        });
+
+        it('updates state when data already exists', () => {
+          const data = { testing: { field: 'test' } };
+          payload = { data };
+          meta = { collection, doc: 'someDoc', subcollections: [{ collection: 'another', doc: 'testing' }] };
+          const existingState = { test: { someDoc: { another: { testing: {} } } } };
+          action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+          expect(dataReducer(existingState, action))
+            .to.have.nested.property('test.someDoc.another.testing.field', data.testing.field);
+        });
+      });
+    });
+
+    describe('GET_SUCCESS', () => {
+      it('returns state if payload is not defined', () => {
+        action = { meta: 'test', type: actionTypes.GET_SUCCESS };
+        expect(dataReducer(state, action)).to.equal(state);
+      });
+
+      it('returns state if payload does not contain data', () => {
+        payload = {};
+        action = { meta: {}, payload, type: actionTypes.GET_SUCCESS };
+        expect(dataReducer(state, action)).to.equal(state);
+      });
+
+      it('updates collection', () => {
+        payload = { data: { abc: { field: 'test' } } };
+        meta = { collection };
+        action = { meta, payload, type: actionTypes.GET_SUCCESS };
+        expect(dataReducer(state, action).test.abc.field).to.equal('test');
+      });
+
+      it('throws for no collection', () => {
+        payload = { data: { abc: {} } };
+        meta = {};
+        action = { meta, payload, type: actionTypes.GET_SUCCESS };
+        expect(() => dataReducer(state, action))
+          .to.throw('Collection is required to construct reducer path.');
+      });
+
+      // TODO: Make this test complete
+      it.skip('merges with existing data', () => {
+        const data = { test: { field: 'test', another: 'test' } };
+        payload = { data };
+        meta = { collection, doc: 'someDoc' };
+        const existingState = { test: { someDoc: { another: 'test' } } };
+        action = { meta, payload, type: actionTypes.GET_SUCCESS };
+        expect(dataReducer(existingState, action))
+          .to.have.nested.property('test', {});
+      });
+
+      describe('with subcollections parameter', () => {
+        it('updates empty state', () => {
+          const data = { abc: { field: 'test' } };
+          payload = { data };
+          meta = { collection, doc: 'someDoc', subcollections: [{ collection: 'another' }] };
+          action = { meta, payload, type: actionTypes.GET_SUCCESS };
+          expect(dataReducer(state, action))
+            .to.have.nested.property('test.someDoc.another', data);
+        });
+
+        it('updates state when data already exists', () => {
+          const data = { testing: { field: 'test' } };
+          payload = { data };
+          meta = { collection, doc: 'someDoc', subcollections: [{ collection: 'another', doc: 'testing' }] };
+          const existingState = { test: { someDoc: { another: { testing: {} } } } };
+          action = { meta, payload, type: actionTypes.GET_SUCCESS };
+          expect(dataReducer(existingState, action))
+            .to.have.nested.property('test.someDoc.another.testing.field', data.testing.field);
+        });
+      });
+    });
+
+    describe('CLEAR_DATA', () => {
+      it('clears data from state', () => {
+        meta = {};
+        action = { meta, type: actionTypes.CLEAR_DATA };
+        expect(dataReducer({ data: { some: {} } }, action)).to.be.empty;
+      });
+
+      it('preserves keys provided in preserve parameter', () => {
+        meta = {};
+        const data = { some: 'test' };
+        action = { meta, type: actionTypes.CLEAR_DATA, preserve: ['some'] };
+        expect(dataReducer(data, action)).to.have.property('some', data.some);
+      });
+    });
   });
 });

--- a/tests/unit/reducers/dataReducer.spec.js
+++ b/tests/unit/reducers/dataReducer.spec.js
@@ -2,8 +2,7 @@ import dataReducer from '../../../src/reducers/dataReducer';
 import { actionTypes } from '../../../src/constants';
 
 const state = {};
-const collection = 'test';
-
+let collection = 'test'; // eslint-disable-line prefer-const
 let action = {};
 let payload = {};
 let meta = {};

--- a/tests/unit/utils/reducers.spec.js
+++ b/tests/unit/utils/reducers.spec.js
@@ -20,11 +20,12 @@ describe('reducer utils', () => {
 
     it('throws for no meta data passed (first argument)', () => {
       expect(() => pathFromMeta())
-        .to.throw('Action meta is required to build path for reducers');
+        .to.throw('Action meta is required to build path for reducers.');
     });
 
     it('returns undefined if provided nothing', () => {
-      expect(pathFromMeta({})).to.not.exist;
+      expect(() => pathFromMeta({}))
+        .to.throw('Collection is required to construct reducer path.');
     });
 
     it('returns collection if provided', () => {
@@ -32,7 +33,8 @@ describe('reducer utils', () => {
     });
 
     it('returns collection doc combined into dot path if both provided', () => {
-      expect(pathFromMeta({ collection: 'first', doc: 'second' })).to.equal('first.second');
+      expect(pathFromMeta({ collection: 'first', doc: 'second' }))
+        .to.equal('first.second');
     });
 
     it('uses storeAs as path if provided', () => {
@@ -56,7 +58,10 @@ describe('reducer utils', () => {
     });
 
     it('supports multiple subcollections', () => {
-      subcollections = [{ collection: 'third', doc: 'forth' }, { collection: 'fifth' }];
+      subcollections = [
+        { collection: 'third', doc: 'forth' },
+        { collection: 'fifth' },
+      ];
       config = { collection: 'first', doc: 'second', subcollections };
       expect(pathFromMeta(config))
         .to.equal('first.second.third.forth.fifth');

--- a/tests/unit/utils/reducers.spec.js
+++ b/tests/unit/utils/reducers.spec.js
@@ -1,0 +1,65 @@
+import { getDotStrPath, pathFromMeta } from '../../../src/utils/reducers';
+
+let subcollections;
+let config;
+
+describe('reducer utils', () => {
+  describe('getDotStrPath', () => {
+    it('is exported', () => {
+      expect(getDotStrPath).to.be.a('function');
+    });
+    it('converts slash path to dot path', () => {
+
+    });
+  });
+
+  describe('pathFromMeta', () => {
+    it('is exported', () => {
+      expect(pathFromMeta).to.be.a('function');
+    });
+
+    it('throws for no meta data passed (first argument)', () => {
+      expect(() => pathFromMeta())
+        .to.throw('Action meta is required to build path for reducers');
+    });
+
+    it('returns undefined if provided nothing', () => {
+      expect(pathFromMeta({})).to.not.exist;
+    });
+
+    it('returns collection if provided', () => {
+      expect(pathFromMeta({ collection: 'test' })).to.equal('test');
+    });
+
+    it('returns collection doc combined into dot path if both provided', () => {
+      expect(pathFromMeta({ collection: 'first', doc: 'second' })).to.equal('first.second');
+    });
+
+    it('uses storeAs as path if provided', () => {
+      pathFromMeta({ storeAs: 'testing' });
+    });
+
+    describe('supports a subcollection', () => {
+      it('with collection', () => {
+        subcollections = [{ collection: 'third' }];
+        config = { collection: 'first', doc: 'second', subcollections };
+        expect(pathFromMeta(config))
+          .to.equal('first.second.third');
+      });
+
+      it('with doc', () => {
+        subcollections = [{ collection: 'third', doc: 'forth' }];
+        config = { collection: 'first', doc: 'second', subcollections };
+        expect(pathFromMeta(config))
+          .to.equal('first.second.third.forth');
+      });
+    });
+
+    it('supports multiple subcollections', () => {
+      subcollections = [{ collection: 'third', doc: 'forth' }, { collection: 'fifth' }];
+      config = { collection: 'first', doc: 'second', subcollections };
+      expect(pathFromMeta(config))
+        .to.equal('first.second.third.forth.fifth');
+    });
+  });
+});


### PR DESCRIPTION
* fix(query): `addOrderBy` & `addWhere` now use reduce - #39 - @danleavitt0 
* fix(reducer): typo was prevent correct usage of `preserve` with `CLEAR_DATA` action
* feat(core): `version` is now exported in all build types (current version of `redux-firestore` as a string)
* feat(utils): `pathFromMeta` util (used in multiple reducers) throws error if `collection` is not passed to `action.meta` (prevents data being written to `"undefined"` key in redux)
* feat(tests): tons of tests added including those for `dataReducer`, `getFirestore`, and multiple utils such as `pathFromMeta`