### PR TITLE
Add missing slash between subcollections and collections/doc query name

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -119,7 +119,7 @@ const getQueryName = (meta) => {
     const mappedCollections = subcollections.map(subcollection =>
       subcollection.collection.concat(subcollection.doc ? `/${subcollection.doc}` : ''),
     );
-    basePath = basePath.concat(mappedCollections.join('/'));
+    basePath = `${basePath}/${mappedCollections.join('/')}`;
   }
   if (where) {
     if (!isArray(where)) {


### PR DESCRIPTION
Turns out if you pass in subcollections it'll be formatted as `{collections}/{doc}{subcollections}`. This PR fixes that to `{collections}/{doc}/{subcollections}`.