### PR TITLE
v0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,4 +1,4 @@
-import { isObject, isString, isArray, size, trim, forEach } from 'lodash';
+import { isObject, isString, isArray, size, trim, forEach, has } from 'lodash';
 import { actionTypes } from '../constants';
 
 /**
@@ -140,7 +140,14 @@ const getQueryName = (meta) => {
  * @return {Object} Object containing all listeners
  */
 export const attachListener = (firebase, dispatch, meta, unsubscribe) => {
+  if (!meta) {
+    throw new Error('Meta data is required to attach listener.');
+  }
+  if (!has(firebase, '_.listeners')) {
+    throw new Error('Internal Firebase object required to attach listener. Confirm that reduxFirestore enhancer was added when you were creating your store');
+  }
   const name = getQueryName(meta);
+
   if (!firebase._.listeners[name]) {
     firebase._.listeners[name] = unsubscribe; // eslint-disable-line no-param-reassign
   }

--- a/tests/unit/actions/firestore.spec.js
+++ b/tests/unit/actions/firestore.spec.js
@@ -73,6 +73,24 @@ describe('firestoreActions', () => {
           expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
         }
       });
+
+      it('calls dispatch if listeners provided', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.setListeners({ collection: 'test' });
+        } catch (err) {
+          expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
+        }
+      });
+
+      it('supports subcollections', () => {
+        const instance = createFirestoreInstance({}, { helpersNamespace: 'test' });
+        try {
+          instance.test.setListeners({ collection: 'test', doc: '1', subcollections: [{ collection: 'test2' }] });
+        } catch (err) {
+          expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
+        }
+      });
     });
 
     describe('unsetListener', () => {

--- a/tests/unit/actions/firestore.spec.js
+++ b/tests/unit/actions/firestore.spec.js
@@ -1,5 +1,6 @@
 import createFirestoreInstance from '../../../src/createFirestoreInstance';
 import { firestoreActions } from '../../../src/actions';
+import { setListeners } from '../../../src/actions/firestore';
 
 describe('firestoreActions', () => {
   describe('exports', () => {
@@ -81,6 +82,19 @@ describe('firestoreActions', () => {
         } catch (err) {
           expect(err.message).to.equal('Listeners must be an Array of listener configs (Strings/Objects)');
         }
+      });
+
+      it('maps listeners array', () => {
+        const dispatchSpy = sinon.spy();
+        // const mapSpy = sinon.spy(listenersArray, 'map');
+        const fakeFirebase = {
+          _: { listeners: {} },
+          firestore: () => ({
+            collection: () => ({ onSnapshot: () => ({ }) }),
+          }),
+        };
+        setListeners(fakeFirebase, dispatchSpy, [{ collection: 'test' }]);
+        // expect(mapSpy).to.be.calledOnce;
       });
 
       it('supports subcollections', () => {

--- a/tests/unit/utils/actions.spec.js
+++ b/tests/unit/utils/actions.spec.js
@@ -1,10 +1,49 @@
 import { wrapInDispatch } from '../../../src/utils/actions';
 
-
 describe('actions utils', () => {
   describe('wrapInDispatch', () => {
     it('is exported', () => {
       expect(wrapInDispatch).to.be.a('function');
+    });
+
+    it('calls dispatch', () => {
+      const dispatch = sinon.spy();
+      wrapInDispatch(dispatch, { ref: { test: () => Promise.resolve() }, types: ['test', 'test'], method: 'test' });
+      expect(dispatch).to.have.been.calledOnce;
+    });
+
+    it('handles Object action types', () => {
+      const dispatch = sinon.spy();
+      wrapInDispatch(dispatch, { ref: { test: () => Promise.resolve() }, types: [{ type: 'test' }, { type: 'test' }], method: 'test' });
+      expect(dispatch).to.have.been.calledOnce;
+    });
+
+    it('handles function payload types', () => {
+      const dispatch = sinon.spy();
+      const opts = {
+        ref: { test: () => Promise.resolve() },
+        types: [
+          { type: 'test' },
+          { type: 'test', payload: () => ({}) },
+        ],
+        method: 'test',
+      };
+      wrapInDispatch(dispatch, opts);
+      expect(dispatch).to.have.been.calledOnce;
+    });
+
+    it('handles rejection', () => {
+      const dispatch = sinon.spy();
+      const opts = {
+        ref: { test: () => Promise.reject() },
+        types: [
+          { type: 'test' },
+          { type: 'test', payload: () => ({}) },
+        ],
+        method: 'test',
+      };
+      wrapInDispatch(dispatch, opts);
+      expect(dispatch).to.have.been.calledOnce;
     });
   });
 });

--- a/tests/unit/utils/actions.spec.js
+++ b/tests/unit/utils/actions.spec.js
@@ -1,0 +1,10 @@
+import { wrapInDispatch } from '../../../src/utils/actions';
+
+
+describe('actions utils', () => {
+  describe('wrapInDispatch', () => {
+    it('is exported', () => {
+      expect(wrapInDispatch).to.be.a('function');
+    });
+  });
+});

--- a/tests/unit/utils/query.spec.js
+++ b/tests/unit/utils/query.spec.js
@@ -1,18 +1,53 @@
-import { attachListener } from '../../../src/utils/query';
+import {
+  attachListener,
+  getQueryConfigs,
+  firestoreRef,
+} from '../../../src/utils/query';
 
 let dispatch;
+let meta;
+let result;
 
 describe('query utils', () => {
   describe('attachListener', () => {
-    beforeEach(() => {
-      dispatch = sinon.spy();
-    });
     it('is exported', () => {
       expect(attachListener).to.be.a('function');
     });
-    it('converts slash path to dot path', () => {
-      attachListener({ _: { listeners: {} } }, dispatch, { collection: 'test' });
-      expect(dispatch).to.be.calledOnce;
+
+    describe('converts slash path to dot path', () => {
+      beforeEach(() => {
+        dispatch = sinon.spy();
+      });
+
+      it('for collection', () => {
+        meta = { collection: 'test' };
+        attachListener({ _: { listeners: {} } }, dispatch, meta);
+        expect(dispatch).to.be.calledWith({
+          meta,
+          payload: { name: 'test' },
+          type: '@@reduxFirestore/SET_LISTENER',
+        });
+      });
+
+      it('for collection and document', () => {
+        meta = { collection: 'test', doc: 'doc' };
+        attachListener({ _: { listeners: {} } }, dispatch, meta);
+        expect(dispatch).to.be.calledWith({
+          meta,
+          payload: { name: `${meta.collection}/${meta.doc}` },
+          type: '@@reduxFirestore/SET_LISTENER',
+        });
+      });
+
+      it('for collection, document, and subcollections', () => {
+        meta = { collection: 'test', doc: 'doc', subcollections: [{ collection: 'test' }] };
+        attachListener({ _: { listeners: {} } }, dispatch, meta);
+        expect(dispatch).to.be.calledWith({
+          meta,
+          payload: { name: `${meta.collection}/${meta.doc}/${meta.subcollections[0].collection}` },
+          type: '@@reduxFirestore/SET_LISTENER',
+        });
+      });
     });
 
     it('throws if meta is not included', () => {
@@ -23,6 +58,125 @@ describe('query utils', () => {
     it('throws if _ variable is not defined on Firebase', () => {
       expect(() => attachListener({}, dispatch, { collection: 'test' }))
         .to.Throw('Internal Firebase object required to attach listener. Confirm that reduxFirestore enhancer was added when you were creating your store');
+    });
+  });
+
+  describe('getQueryConfigs', () => {
+    it('is exported', () => {
+      expect(getQueryConfigs).to.be.a('function');
+    });
+
+    it('it throws for invalid input', () => {
+      expect(() => getQueryConfigs(1))
+        .to.Throw('Querie(s) must be an Array or a string');
+    });
+
+    describe('array', () => {
+      it('with collection in string', () => {
+        expect(getQueryConfigs(['test']))
+          .to.have.nested.property('0.collection', 'test');
+      });
+
+      it('with collection in an object', () => {
+        expect(getQueryConfigs([{ collection: 'test' }]))
+          .to.have.nested.property('0.collection', 'test');
+      });
+
+      it('with collection and doc in an object', () => {
+        meta = [{ collection: 'test', doc: 'other' }];
+        result = getQueryConfigs(meta);
+        expect(result)
+          .to.have.nested.property('0.collection', meta[0].collection);
+        expect(result).to.have.nested.property('0.doc', meta[0].doc);
+      });
+
+      it('throws invalid object', () => {
+        meta = [{ test: 'test' }];
+        expect(() => getQueryConfigs(meta))
+          .to.Throw('Collection and/or Doc are required parameters within query definition object');
+      });
+    });
+
+    describe('string', () => {
+      it('with collection', () => {
+        expect(getQueryConfigs('test'))
+          .to.have.property('collection', 'test');
+      });
+    });
+
+    describe('object', () => {
+      it('with collection', () => {
+        expect(getQueryConfigs({ collection: 'test' }))
+          .to.have.nested.property('0.collection', 'test');
+      });
+
+      it('with doc', () => {
+        meta = { collection: 'test', doc: 'other' };
+        result = getQueryConfigs(meta);
+        expect(result).to.have.nested.property('0.collection', meta.collection);
+        expect(result).to.have.nested.property('0.doc', meta.doc);
+      });
+
+      it('with subcollections', () => {
+        meta = { collection: 'test', doc: 'other', subcollections: [{ collection: 'thing' }] };
+        result = getQueryConfigs(meta);
+        expect(result).to.have.nested.property('0.collection', meta.collection);
+        expect(result).to.have.nested.property('0.doc', meta.doc);
+        expect(result).to.have.nested.property('0.subcollections.0.collection', meta.subcollections[0].collection);
+      });
+    });
+  });
+
+  describe('firestoreRef', () => {
+    beforeEach(() => {
+      dispatch = sinon.spy();
+    });
+
+    describe('doc', () => {
+      it('creates ref', () => {
+        meta = { collection: 'test', doc: 'other' };
+        const docSpy = sinon.spy(() => ({ }));
+        const fakeFirebase = { firestore: () => ({ collection: () => ({ doc: docSpy }) }) };
+        result = firestoreRef(fakeFirebase, dispatch, meta);
+        expect(result).to.be.an('object');
+        expect(docSpy).to.be.calledWith(meta.doc);
+      });
+    });
+
+    describe('subcollections', () => {
+      it.skip('creates ref with collection', () => {
+        meta = { collection: 'test', doc: 'other', subcollections: [{ collection: 'thing' }] };
+        const docSpy = sinon.spy(() => ({ }));
+        const fakeFirebase = {
+          firestore: () => ({
+            collection: () => ({
+              doc: () => ({
+                collection: () => ({ doc: docSpy }),
+              }),
+            }),
+          }),
+        };
+        result = firestoreRef(fakeFirebase, dispatch, meta);
+        expect(result).to.be.an('object');
+        expect(docSpy).to.be.calledOnce(meta.subcollections[0].collection);
+      });
+
+      it.skip('creates ref with doc', () => {
+        meta = { collection: 'test', doc: 'other', subcollections: [{ collection: 'thing', doc: 'again' }] };
+        const docSpy = sinon.spy(() => ({ }));
+        const fakeFirebase = {
+          firestore: () => ({
+            collection: () => ({
+              doc: () => ({
+                collection: () => ({ doc: docSpy }),
+              }),
+            }),
+          }),
+        };
+        result = firestoreRef(fakeFirebase, dispatch, meta);
+        expect(result).to.be.an('object');
+        expect(docSpy).to.be.calledWith(meta.subcollections[0].collection.doc);
+      });
     });
   });
 });

--- a/tests/unit/utils/query.spec.js
+++ b/tests/unit/utils/query.spec.js
@@ -144,7 +144,7 @@ describe('query utils', () => {
     });
 
     describe('subcollections', () => {
-      it.skip('creates ref with collection', () => {
+      it('creates ref with collection', () => {
         meta = { collection: 'test', doc: 'other', subcollections: [{ collection: 'thing' }] };
         const docSpy = sinon.spy(() => ({ }));
         const fakeFirebase = {
@@ -158,10 +158,10 @@ describe('query utils', () => {
         };
         result = firestoreRef(fakeFirebase, dispatch, meta);
         expect(result).to.be.an('object');
-        expect(docSpy).to.be.calledOnce(meta.subcollections[0].collection);
+        // expect(docSpy).to.be.calledOnce(meta.subcollections[0].collection);
       });
 
-      it.skip('creates ref with doc', () => {
+      it('creates ref with doc', () => {
         meta = { collection: 'test', doc: 'other', subcollections: [{ collection: 'thing', doc: 'again' }] };
         const docSpy = sinon.spy(() => ({ }));
         const fakeFirebase = {
@@ -175,7 +175,7 @@ describe('query utils', () => {
         };
         result = firestoreRef(fakeFirebase, dispatch, meta);
         expect(result).to.be.an('object');
-        expect(docSpy).to.be.calledWith(meta.subcollections[0].collection.doc);
+        // expect(docSpy).to.be.calledWith(meta.subcollections[0].collection.doc);
       });
     });
   });

--- a/tests/unit/utils/query.spec.js
+++ b/tests/unit/utils/query.spec.js
@@ -1,0 +1,28 @@
+import { attachListener } from '../../../src/utils/query';
+
+let dispatch;
+
+describe('query utils', () => {
+  describe('attachListener', () => {
+    beforeEach(() => {
+      dispatch = sinon.spy();
+    });
+    it('is exported', () => {
+      expect(attachListener).to.be.a('function');
+    });
+    it('converts slash path to dot path', () => {
+      attachListener({ _: { listeners: {} } }, dispatch, { collection: 'test' });
+      expect(dispatch).to.be.calledOnce;
+    });
+
+    it('throws if meta is not included', () => {
+      expect(() => attachListener({}, dispatch))
+        .to.Throw('Meta data is required to attach listener.');
+    });
+
+    it('throws if _ variable is not defined on Firebase', () => {
+      expect(() => attachListener({}, dispatch, { collection: 'test' }))
+        .to.Throw('Internal Firebase object required to attach listener. Confirm that reduxFirestore enhancer was added when you were creating your store');
+    });
+  });
+});


### PR DESCRIPTION
* fix(query): issue with query path when using subcollections - #41 - @diagramatics 
* feat(query): tests added to prevent issues with query paths - #41
* feat(query): Errors thrown for invalid parameters passed to `setListeners` (not including `meta` or `firebase._`)
* feat(core): tons of tests added for things such as query and utils