### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class Todos extends Component {
   }
 
   componentWillMount () {
-    const { firebase } = this.context.store
+    const { firestore } = this.context.store
     firestore.get('todos')
   }
 


### PR DESCRIPTION
### Description

In Component Class section, `const { firebase } = this.context.store` should be `const { firestore } = this.context.store`.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
