### PR TITLE
fix(query): multiple where and orderBy arguments

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -15,7 +15,8 @@ function addWhereToRef(ref, where) {
   if (isString(where[0])) {
     return where.length > 1 ? ref.where(...where) : ref.where(where[0]);
   }
-  return where.reduce((acc, whereArgs) => addWhereToRef(ref, whereArgs), ref);
+
+  return where.reduce((acc, whereArgs) => addWhereToRef(acc, whereArgs), ref);
 }
 
 /**
@@ -37,7 +38,7 @@ function addOrderByToRef(ref, orderBy) {
     return ref.orderBy(...orderBy);
   }
   return orderBy.reduce(
-    (acc, orderByArgs) => addOrderByToRef(ref, orderByArgs),
+    (acc, orderByArgs) => addOrderByToRef(acc, orderByArgs),
     ref,
   );
 }


### PR DESCRIPTION
Due to the last changes in the way we build the query (using recursive function) if one has 2 parameters for example:
      where: [
        ['company_id', '==', companyId],
        ['active', '==', true],
      ],

only the last array would be used for the query, because we call the recursive function not with the accumulator from .reduce, but with the original ref that was passed to the function

### Description


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
