### PR TITLE
v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,61 @@ const enhance = compose(
 export default enhance(SomeComponent)
 ```
 
+## Config Options
+
+#### enableLogging
+Default: `false`
+
+Whether or not to enable Firebase client logging.
+
+#### logListenerError
+Default: `true`
+
+Whether or not to use `console.error` to log listener error objects. Errors from listeners are helpful to developers on multiple occasions including when index needs to be added.
+
+#### enhancerNamespace
+Default: `'firestore'`
+
+Namespace under which enhancer places internal instance on redux store (i.e. `store.firestore`).
+
+#### allowMultipleListeners
+Default: `false`
+
+Whether or not to allow multiple listeners to be attached for the same query. If a function is passed the arguments it receives are `listenerToAttach`, `currentListeners`, and the function should return a boolean.
+
+#### preserveOnDelete
+Default: `null`
+
+Values to preserve from state when DELETE_SUCCESS action is dispatched. Note that this will not prevent the LISTENER_RESPONSE action from removing items from state.ordered if you have a listener attached.
+
+#### preserveOnListenerError
+Default: `null`
+
+Values to preserve from state when LISTENER_ERROR action is dispatched.
+
+#### onAttemptCollectionDelete
+Default: `null`
+
+Arguments:`(queryOption, dispatch, firebase)`
+
+Function run when attempting to delete a collection. If not provided (default) delete promise will be rejected with "Only documents can be deleted" unless. This is due to the fact that Collections can not be deleted from a client, it should instead be handled within a cloud function (which can be called by providing a promise to `onAttemptCollectionDelete` that calls the cloud function).
+
+#### mergeOrdered
+Default: `true`
+
+Whether or not to merge data within `orderedReducer`.
+
+#### mergeOrderedDocUpdate
+Default: `true`
+
+Whether or not to merge data from document listener updates within `orderedReducer`.
+
+
+#### mergeOrderedCollectionUpdates
+Default: `true`
+
+Whether or not to merge data from collection listener updates within `orderedReducer`.
+
 <!-- #### Middleware
 
 `redux-firestore`'s enhancer offers a new middleware setup that was not offered in `react-redux-firebase` (but will eventually make it `redux-firebase`)

--- a/README.md
+++ b/README.md
@@ -461,7 +461,11 @@ Note: In an effort to keep things simple, the wording from this explanation was 
 
 1. How do I get auth state in redux?
 
-You will most likely want to use [`react-redux-firebase`](https://github.com/prescottprue/react-redux-firebase) or another redux/firebase connector. For more information please visit the [complementary package section](#complementary-package).
+    You will most likely want to use [`react-redux-firebase`](https://github.com/prescottprue/react-redux-firebase) or another redux/firebase connector. For more information please visit the [complementary package section](#complementary-package).
+
+1. Are there Higher Order Components for use with React?
+
+    [`react-redux-firebase`](https://github.com/prescottprue/react-redux-firebase) contains `firebaseConnect`, `firestoreConnect`, `withFirebase` and `withFirestore` HOCs. For more information please visit the [complementary package section](#complementary-package).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Most likely, you'll want react bindings, for that you will need [react-redux-fir
 npm install --save react-redux-firebase
 ```
 
-[react-redux-firebase](https://github.com/prescottprue/react-redux-firebase) provides [`withFirestore`](http://docs.react-redux-firebase.com/history/v2.0.0/docs/api/withFirestore.html) and [`firestoreConnect`](http://docs.react-redux-firebase.com/history/v2.0.0/docs/api/withFirestore.html) higher order components, which handle automatically calling `redux-firestore` internally based on component's lifecycle (i.e. mounting/un-mounting)
+[react-redux-firebase](https://github.com/prescottprue/react-redux-firebase) provides [`withFirestore`](http://react-redux-firebase.com/docs/api/withFirestore.html) and [`firestoreConnect`](http://react-redux-firebase.com/docs/api/firestoreConnect.html) higher order components, which handle automatically calling `redux-firestore` internally based on component's lifecycle (i.e. mounting/un-mounting)
 
 ## Use
 
@@ -442,6 +442,26 @@ Note: In an effort to keep things simple, the wording from this explanation was 
 
 ## Applications Using This
 * [fireadmin.io](http://fireadmin.io) - Firebase Instance Management Tool (source [available here](https://github.com/prescottprue/fireadmin))
+
+## FAQ
+1. How do I update a document within a subcollection?
+
+    Provide `subcollections` config the same way you do while querying:
+
+    ```js
+    props.firestore.update(
+      {
+        collection: 'cities',
+        doc: 'SF',
+        subcollections: [{ collection: 'counties', doc: 'San Mateo' }],
+      },
+      { some: 'changes' }
+    );
+    ```
+
+1. How do I get auth state in redux?
+
+You will most likely want to use [`react-redux-firebase`](https://github.com/prescottprue/react-redux-firebase) or another redux/firebase connector. For more information please visit the [complementary package section](#complementary-package).
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -184,14 +184,26 @@ export function setListener(firebase, dispatch, queryOpts, successCb, errorCb) {
     err => {
       // TODO: Look into whether listener is automatically removed in all cases
       // TODO: Provide a setting that allows for silencing of console error
-      const { config } = firebase._;
+      const {
+        config: {
+          mergeOrdered,
+          logListenerError,
+          mergeOrderedDocUpdates,
+          mergeOrderedCollectionUpdates,
+          preserveOnListenerError,
+        },
+      } = firebase._;
       // Log error handling the case of it not existing
-      if (config.logListenerError) invoke(console, 'error', err);
+      if (logListenerError) invoke(console, 'error', err);
       dispatch({
         type: actionTypes.LISTENER_ERROR,
         meta,
         payload: err,
-        preserve: config.preserveOnListenerError,
+        merge: {
+          docs: mergeOrdered && mergeOrderedDocUpdates,
+          collections: mergeOrdered && mergeOrderedCollectionUpdates,
+        },
+        preserve: preserveOnListenerError,
       });
       // Invoke error callback if it exists
       if (errorCb) errorCb(err);

--- a/src/constants.js
+++ b/src/constants.js
@@ -115,6 +115,9 @@ export const defaultConfig = {
   preserveOnDelete: null,
   preserveOnListenerError: null,
   onAttemptCollectionDelete: null,
+  mergeOrdered: true,
+  mergeOrderedDocUpdates: true,
+  mergeOrderedCollectionUpdates: true,
 };
 
 export default {

--- a/src/constants.js
+++ b/src/constants.js
@@ -91,7 +91,7 @@ export const actionTypes = {
  * state.ordered if you have a listener attached.
  * @property {Object} preserveOnListenerError - `null` Values to
  * preserve from state when LISTENER_ERROR action is dispatched.
- * @property {Boolean} enhancerNamespace - `'firestore'` Namespace underwhich
+ * @property {Boolean} enhancerNamespace - `'firestore'` Namespace under which
  * enhancer places internal instance on redux store (i.e. store.firestore).
  * @property {Boolean|Function} allowMultipleListeners - `null` Whether or not
  * to allow multiple listeners to be attached for the same query. If a function

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -1,5 +1,5 @@
 import { get } from 'lodash';
-import { setWith, assign } from 'lodash/fp';
+import { setWith, merge } from 'lodash/fp';
 import { actionTypes } from '../constants';
 import { pathFromMeta, preserveValuesFromState } from '../utils/reducers';
 
@@ -50,7 +50,7 @@ export default function dataReducer(state = {}, action) {
         return setWith(Object, pathFromMeta(meta), data, state);
       }
       // Otherwise merge with existing data
-      const mergedData = assign(previousData, data);
+      const mergedData = merge(previousData, data);
       // Set data to state (with merge) immutabily (lodash/fp's setWith creates copy)
       return setWith(Object, pathFromMeta(meta), mergedData, state);
     case DELETE_SUCCESS:

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -65,7 +65,7 @@ export default function orderedReducer(state = {}, action) {
       if (!action.payload || !action.payload.ordered) {
         return state;
       }
-      const { meta, merge = {} } = action;
+      const { meta, merge = { doc: true, collection: true } } = action;
       const parentPath = meta.storeAs || meta.collection;
       // Handle doc update (update item in array instead of whole array)
       if (meta.doc && merge.doc && size(get(state, parentPath))) {

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -47,6 +47,10 @@ export function wrapInDispatch(
       if (successIsObject && successType.preserve) {
         actionObj.preserve = successType.preserve;
       }
+      // Attach merge to action if it is passed
+      if (successIsObject && successType.merge) {
+        actionObj.merge = successType.merge;
+      }
       dispatch(actionObj);
       return result;
     })

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -69,7 +69,7 @@ function handleSubcollections(ref, subcollectionList) {
       if (subcollection.collection) {
         if (!isFunction(ref.collection)) {
           throw new Error(
-            `Collection can only be created on a document. Check that query config for subcollection: "${
+            `Collection can only be run on a document. Check that query config for subcollection: "${
               subcollection.collection
             }" contains a doc parameter.`,
           );

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -62,17 +62,21 @@ describe('dataReducer', () => {
           doc,
         };
         const existingState = {
-          [collection]: { [doc]: { originalData: { some: {} } } },
+          [collection]: { [doc]: { originalData: { some: { val: 'test' } } } },
         };
-        action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+        action = {
+          meta,
+          payload,
+          type: actionTypes.LISTENER_RESPONSE,
+        };
         result = dataReducer(existingState, action);
         expect(result).to.have.nested.property(
           `${collection}.${doc}.newData.field`,
           data[doc].newData.field,
         );
         expect(result).to.have.nested.property(
-          `${collection}.${doc}.originalData.some`,
-          existingState[collection][doc].originalData.some,
+          `${collection}.${doc}.originalData.some.val`,
+          existingState[collection][doc].originalData.some.val,
         );
       });
 

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -56,6 +56,22 @@ describe('orderedReducer', () => {
         );
       });
 
+      it('merges collection already within state', () => {
+        const id = 'doc';
+        const someField = 'a thing';
+        const orderedData = [{ id, someField }];
+        action = {
+          meta: { collection: 'testing' },
+          type: actionTypes.LISTENER_RESPONSE,
+          payload: { ordered: orderedData },
+        };
+        state = { testing: [{ id: 'some', someField: 'original' }] };
+        expect(orderedReducer(state, action)).to.have.nested.property(
+          'testing.1.someField',
+          someField,
+        );
+      });
+
       describe('doc', () => {
         it.skip('adds a new doc within state', () => {
           const orderedData = { id: 'doc' };

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -14,6 +14,7 @@ let meta;
 let result;
 let docSpy;
 let fakeFirebase;
+const collection = 'test';
 
 const fakeFirebaseWith = spyedName => {
   const theSpy = sinon.spy(() => ({}));
@@ -186,7 +187,6 @@ describe('query utils', () => {
 
     it('calls dispatch with unlisten actionType', () => {
       const callbackSpy = sinon.spy();
-      const collection = 'test';
       detachListener({ _: { listeners: { test: callbackSpy } } }, dispatch, {
         collection,
       });
@@ -313,6 +313,26 @@ describe('query utils', () => {
     });
 
     describe('subcollections', () => {
+      it('throws if trying to get doc not provided', () => {
+        const subcollection = 'thing';
+        meta = {
+          collection,
+          subcollections: [{ collection: subcollection, doc: 'again' }],
+        };
+        fakeFirebase = {
+          firestore: () => ({
+            collection: () => ({
+              doc: () => ({
+                collection: () => ({ doc: docSpy }),
+              }),
+            }),
+          }),
+        };
+        expect(() => firestoreRef(fakeFirebase, dispatch, meta)).to.throw(
+          `Collection can only be run on a document. Check that query config for subcollection: "${subcollection}" contains a doc parameter.`,
+        );
+      });
+
       it('creates ref with collection', () => {
         meta = {
           collection: 'test',


### PR DESCRIPTION
### Description
* fix(query): multiple `where` or `orderBy` parameters - compojoom
* fix(orderedReducer): subcollection not updating `state.ordered` - #46
* fix(orderedReducer): multiple subcollections on same parent collection correctly merges doc data - #34
* fix(dataReducer): setListeners clears out the subcollection of a document - #49
* feat(orderedReducer): `mergeOrdered`, `mergeOrderedDocUpdates`, and `mergeOrderedCollectionUpdates` config options added to allow for enabling/disabling merging of ordered data within `orderedReducer`
* feat(README): FAQ section added to clarify common questions - #47
* feat(README): Config Options section added to explain config options and their default values

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #34
* #46
* #47
* #49
