### PR TITLE
Count listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,11 @@ Default: `false`
 
 Whether or not to allow multiple listeners to be attached for the same query. If a function is passed the arguments it receives are `listenerToAttach`, `currentListeners`, and the function should return a boolean.
 
+### oneListenerPerPath
+Default: `false`
+
+If set to true redux-firestore will attach a listener on the same path just once & will count how many the listener was set. When you try to unset the lisnter, it won't unset until you have less than 1 listeners on this path
+
 #### preserveOnDelete
 Default: `null`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
     "watch": "npm run build:es -- --watch",
+    "watch:commonjs": "npm run build:commonjs -- --watch",
     "test": "mocha -R spec ./test/unit/**",
     "test:cov": "istanbul cover ./node_modules/mocha/bin/_mocha ./test/unit/**",
     "codecov": "cat coverage/lcov.info | codecov",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -309,12 +309,12 @@ export function unsetListeners(firebase, dispatch, listeners) {
 
   if (oneListenerPerPath) {
     listeners.forEach(listener => {
-      const path = getQueryName(listener)
-      pathListenerCounts[path] -= 1
+      const path = getQueryName(listener);
+      pathListenerCounts[path] -= 1;
 
       // If we aren't supposed to have listners for this path, then remove them
       if (pathListenerCounts[path] === 0) {
-        unsetListener(firebase, dispatch, listener)
+        unsetListener(firebase, dispatch, listener);
       }
     });
 

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -8,8 +8,11 @@ import {
   orderedFromSnap,
   dataByIdSnapshot,
   getQueryConfig,
+  getQueryName,
   firestoreRef,
 } from '../utils/query';
+
+const pathListenerCounts = {};
 
 /**
  * Add data to a collection or document on Cloud Firestore with the call to
@@ -240,12 +243,31 @@ export function setListeners(firebase, dispatch, listeners) {
     );
   }
 
+  const { config } = firebase._;
+  const oneListenerPerPath = !!config.oneListenerPerPath;
+
+  if (oneListenerPerPath) {
+    return listeners.forEach(listener => {
+      const path = getQueryName(listener);
+      const oldListenerCount = pathListenerCounts[path] || 0;
+      pathListenerCounts[path] = oldListenerCount + 1;
+
+      // If we already have an attached listener exit here
+      if (oldListenerCount > 0) {
+        return;
+      }
+
+      setListener(firebase, dispatch, listener);
+    });
+  }
+
   return listeners.forEach(listener => {
     // Config for supporting attaching of multiple listeners
-    const { config } = firebase._;
+
     const multipleListenersEnabled = isFunction(config.allowMultipleListeners)
       ? config.allowMultipleListeners(listener, firebase._.listeners)
       : config.allowMultipleListeners;
+
     // Only attach listener if it does not already exist or
     // if multiple listeners config is true or is a function which returns
     // truthy value
@@ -281,6 +303,22 @@ export function unsetListeners(firebase, dispatch, listeners) {
     throw new Error(
       'Listeners must be an Array of listener configs (Strings/Objects).',
     );
+  }
+  const { config } = firebase._;
+  const oneListenerPerPath = !!config.oneListenerPerPath;
+
+  if (oneListenerPerPath) {
+    listeners.forEach(listener => {
+      const path = getQueryName(listener)
+      pathListenerCounts[path] -= 1
+
+      // If we aren't supposed to have listners for this path, then remove them
+      if (pathListenerCounts[path] === 0) {
+        unsetListener(firebase, dispatch, listener)
+      }
+    });
+
+    return;
   }
 
   listeners.forEach(listener => {


### PR DESCRIPTION
### Description

don’t attach multiple listeners for the same path, but keep count

Basically the same one as here:
prescottprue/react-redux-firebase#392 but this time one can turn it on or off.

The implementation that we currently have config.allowMultipleListeners might work for some, but in our case it was attaching way to many listeners to the same data. Despite the fact that the listeners returned the same data, we were sill dispatching set_listener and response events on the store and this caused a noticable lag.

if we turn off config.allowMultipleListeners, then everything seems fine to the moment where we attach the same listener on a scene and unmount the scene - the original listener also gets unmounted…

With this change we keep a count and don’t trigger the unsetListener function unless there are no more listeners for this path.

### Check List
If not relevant to pull request, check off as complete

- [ x] All tests passing
- [ x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
