### PR TITLE
Fix queryStr parsing of deep nested collections

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -263,15 +263,16 @@ export function detachListener(firebase, dispatch, meta) {
  * @param  {String} queryPathStr String to be converted
  * @return {Object} Object containing collection, doc and subcollection
  */
-export function queryStrToObj(queryPathStr) {
-  const pathArr = trim(queryPathStr, ['/']).split('/');
-  const [collection, doc, subCollection, ...other] = pathArr;
-  return {
-    collection,
-    doc,
-    subCollection,
-    other,
-  };
+export function queryStrToObj(queryPathStr, parsedPath) {
+  const pathArr = parsedPath || trim(queryPathStr, ['/']).split('/');
+  const [collection, doc, ...subcollections] = pathArr;
+  const queryObj = {};
+  if (collection) queryObj.collection = collection;
+  if (doc) queryObj.doc = doc;
+  if (subcollections.length) {
+    queryObj.subcollections = [queryStrToObj('', subcollections)];
+  }
+  return queryObj;
 }
 
 /**

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -261,6 +261,28 @@ describe('query utils', () => {
       it('with collection', () => {
         expect(getQueryConfigs('test')).to.have.property('collection', 'test');
       });
+
+      it('with nested subcollections', () => {
+        meta = {
+          collection: 'test',
+          doc: 'other',
+          subcollections: [
+            {
+              collection: 'col2',
+              doc: 'doc2',
+              subcollections: [
+                {
+                  collection: 'col3',
+                  doc: 'doc3',
+                  subcollections: [{ collection: 'col4' }],
+                },
+              ],
+            },
+          ],
+        };
+        result = getQueryConfigs('/test/other/col2/doc2/col3/doc3/col4');
+        expect(result).to.be.deep.equal(meta);
+      });
     });
 
     describe('object', () => {
@@ -291,6 +313,28 @@ describe('query utils', () => {
           '0.subcollections.0.collection',
           meta.subcollections[0].collection,
         );
+      });
+
+      it('with nested subcollections', () => {
+        meta = {
+          collection: 'test',
+          doc: 'other',
+          subcollections: [
+            {
+              collection: 'col2',
+              doc: 'doc2',
+              subcollections: [
+                {
+                  collection: 'col3',
+                  doc: 'doc3',
+                  subcollections: [{ collection: 'col4' }],
+                },
+              ],
+            },
+          ],
+        };
+        result = getQueryConfigs(meta);
+        expect(result).to.be.deep.equal([meta]);
       });
     });
   });


### PR DESCRIPTION
### Description
Fix query string parsing.
The queryStrToObj function is currently creating the wrong queryObj causing operations in the wrong document, for instance,  an update to /col1/doc1/col2/doc2/col3/doc3 would generate a wrong update on doc1.
The queryStrToObj now returns a nested config object using the subcollections syntax.

```
{
    "collection": "col1",
    "doc": "doc1",
    "subcollections": [
        {
            "collection": "col2",
            "doc": "doc2",
            "subcollections": [
                {
                    "collection": "col3",
                    "doc": "doc3"
                }
            ]
        }
    ]
}
```

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
