### PR TITLE
v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Storing data under a different path within redux is as easy as passing the `stor
 },
 ```
 
-**NOTE:** Not yet supported inside of subcollections (only at the top level)
+**NOTE:** Usage of `"/"` and `"."` within `storeAs` can cause unexpected behavior when attempting to retrieve from redux state
 
 
 #### Other Firebase Statics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -179,7 +179,7 @@ const changeTypeToEventType = {
 function docChangeEvent(change, originalMeta = {}) {
   return {
     type: changeTypeToEventType[change.type] || actionTypes.DOCUMENT_MODIFIED,
-    meta: { ...originalMeta, doc: change.doc.id },
+    meta: { ...originalMeta, doc: change.doc.id, path: change.doc.ref.path },
     payload: {
       data: change.doc.data(),
       ordered: { oldIndex: change.oldIndex, newIndex: change.newIndex },

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -46,16 +46,21 @@ export default function dataReducer(state = {}, action) {
       // Data to set to state is doc if doc name exists within meta
       const data = docName ? get(payload.data, docName) : payload.data;
       // Get previous data at path to check for existence
-      const previousData = get(state, pathFromMeta(meta));
+      const previousData = get(state, meta.storeAs || pathFromMeta(meta));
       // Set data (without merging) if no previous data exists or if there are subcollections
       if (!previousData || meta.subcollections) {
         // Set data to state immutabily (lodash/fp's setWith creates copy)
-        return setWith(Object, pathFromMeta(meta), data, state);
+        return setWith(Object, meta.storeAs || pathFromMeta(meta), data, state);
       }
       // Otherwise merge with existing data
       const mergedData = assign(previousData, data);
       // Set data to state (with merge) immutabily (lodash/fp's setWith creates copy)
-      return setWith(Object, pathFromMeta(meta), mergedData, state);
+      return setWith(
+        Object,
+        meta.storeAs || pathFromMeta(meta),
+        mergedData,
+        state,
+      );
     case DOCUMENT_MODIFIED:
     case DOCUMENT_ADDED:
       return setWith(

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -75,6 +75,10 @@ function writeCollection(collectionState, action) {
   // Handle subcollections (only when storeAs is not being used)
   if (meta.doc && meta.subcollections && !meta.storeAs) {
     if (!size(collectionState)) {
+      // return storeAs
+      if (meta.storeAs) {
+        return action.payload.ordered;
+      }
       // Collection state does not already exist, create it with item containing
       // subcollection
       return [

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -75,10 +75,6 @@ function writeCollection(collectionState, action) {
   // Handle subcollections (only when storeAs is not being used)
   if (meta.doc && meta.subcollections && !meta.storeAs) {
     if (!size(collectionState)) {
-      // return storeAs
-      if (meta.storeAs) {
-        return action.payload.ordered;
-      }
       // Collection state does not already exist, create it with item containing
       // subcollection
       return [

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -72,8 +72,8 @@ function writeCollection(collectionState, action) {
     return unionBy(collectionState, action.payload.ordered, 'id');
   }
 
-  // Handle subcollections
-  if (meta.doc && meta.subcollections) {
+  // Handle subcollections (only when storeAs is not being used)
+  if (meta.doc && meta.subcollections && !meta.storeAs) {
     if (!size(collectionState)) {
       // Collection state does not already exist, create it with item containing
       // subcollection
@@ -91,11 +91,14 @@ function writeCollection(collectionState, action) {
       }),
     );
   }
+
   if (meta.doc && size(collectionState)) {
-    return updateItemInArray(collectionState, meta.doc, item =>
+    // Update item in array (handling storeAs)
+    return updateItemInArray(collectionState, meta.storeAs || meta.doc, item =>
       mergeObjects(item, action.payload.ordered[0]),
     );
   }
+
   return action.payload.ordered;
 }
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -143,7 +143,7 @@ export function firestoreRef(firebase, dispatch, meta) {
  */
 function whereToStr(where) {
   return isString(where[0])
-    ? `where::${where.join('')}`
+    ? `where=${where.join(':')}`
     : where.map(whereToStr);
 }
 
@@ -160,7 +160,7 @@ export function getQueryName(meta) {
   if (isString(meta)) {
     return meta;
   }
-  const { collection, doc, subcollections, where } = meta;
+  const { collection, doc, subcollections, where, limit } = meta;
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }
@@ -178,7 +178,11 @@ export function getQueryName(meta) {
     if (!isArray(where)) {
       throw new Error('where parameter must be an array.');
     }
-    return basePath.concat(`?${whereToStr(where)}`);
+    basePath = basePath.concat(`?${whereToStr(where)}`);
+  }
+  if (typeof limit !== 'undefined') {
+    const limitStr = `limit=${limit}`;
+    basePath = basePath.concat(`${where ? '&' : '?'}${limitStr}`);
   }
   return basePath;
 }

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -80,6 +80,9 @@ export function pathFromMeta(meta) {
   if (storeAs) {
     return doc ? `${storeAs}.${doc}` : storeAs;
   }
+  if (meta.path) {
+    return meta.path.split('/');
+  }
   if (!collection) {
     throw new Error('Collection is required to construct reducer path.');
   }

--- a/test/unit/actions/firestore.spec.js
+++ b/test/unit/actions/firestore.spec.js
@@ -227,12 +227,20 @@ describe('firestoreActions', () => {
             func({
               docChanges: [
                 {
-                  doc: { id: '123ABC', data: () => ({ some: 'value' }) },
+                  doc: {
+                    id: '123ABC',
+                    data: () => ({ some: 'value' }),
+                    ref: {
+                      path: 'test/1/test2/test3',
+                    },
+                  },
                   type: 'modified',
                 },
               ],
               size: 2,
-              doc: { id: '123ABC' },
+              doc: {
+                id: '123ABC',
+              },
             });
             func2(sinon.spy());
           });
@@ -261,11 +269,23 @@ describe('firestoreActions', () => {
             func({
               docChanges: [
                 {
-                  doc: { id: '123ABC', data: () => ({ some: 'value' }) },
+                  doc: {
+                    id: '123ABC',
+                    data: () => ({ some: 'value' }),
+                    ref: {
+                      path: 'test/1/test2/test3',
+                    },
+                  },
                   type: 'modified',
                 },
                 {
-                  doc: { id: '123ABC', data: () => ({ some: 'value' }) },
+                  doc: {
+                    id: '234ABC',
+                    data: () => ({ some: 'value' }),
+                    ref: {
+                      path: 'test/1/test2/test3',
+                    },
+                  },
                   type: 'modified',
                 },
               ],

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -81,6 +81,7 @@ describe('query utils', () => {
       it('is appended if valid', () => {
         const where1 = 'some';
         const where2 = 'other';
+        const whereOperator = '==';
         meta = {
           collection: 'test',
           doc: 'doc',
@@ -88,7 +89,9 @@ describe('query utils', () => {
         };
         result = getQueryName(meta);
         expect(result).to.equal(
-          `${meta.collection}/${meta.doc}?where::${where1}==${where2}`,
+          `${meta.collection}/${
+            meta.doc
+          }?where=${where1}:${whereOperator}:${where2}`,
         );
       });
     });

--- a/test/unit/utils/reducers.spec.js
+++ b/test/unit/utils/reducers.spec.js
@@ -71,6 +71,10 @@ describe('reducer utils', () => {
       pathFromMeta({ storeAs: 'testing' });
     });
 
+    it('uses path as path if provided', () => {
+      expect(pathFromMeta({ path: 'testing' })).to.have.property(0, 'testing');
+    });
+
     describe('updateItemInArray', () => {
       it('is exported', () => {
         expect(updateItemInArray).to.be.a('function');


### PR DESCRIPTION
### Description
* fix(query): `DOCUMENT_MODIFIED` action correctly updates data reducer when using nested collections in solution from @compojoom  - #88
* fix(query): fixed issue where `limit` was not included in query name - #90
* feat(query): `storeAs` support for subcollections
* feat(query): where now uses `=` in place of `::` within query string name (matches other query params)

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #88
* #90
