### PR TITLE
v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ For more information [on using recompose visit the docs](https://github.com/acdl
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { isEqual } from 'lodash'
 import { watchEvents, unWatchEvents } from './actions/query'
 import { getEventsFromInput, createCallable } from './utils'
 
@@ -163,6 +162,58 @@ class Todos extends Component {
 export default connect((state) => ({
   todos: state.firestore.ordered.todos
 }))(Todos)
+```
+### API
+#### Actions
+
+##### get
+```js
+store.firestore.get({ collection: 'cities' }),
+// store.firestore.get({ collection: 'cities', doc: 'SF' }), // doc
+```
+
+##### set
+```js
+store.firestore.set({ collection: 'cities', doc: 'SF' }, { name: 'San Francisco' }),
+```
+
+##### add
+```js
+store.firestore.add({ collection: 'cities' }, { name: 'Some Place' }),
+```
+
+##### update
+```js
+const itemUpdates =  {
+  some: 'value',
+  updatedAt: store.firestore.FieldValue.serverTimestamp()
+}
+
+store.firestore.update({ collection: 'cities', doc: 'SF' }, itemUpdates),
+```
+
+##### delete
+```js
+store.firestore.delete({ collection: 'cities', doc: 'SF' }),
+```
+
+##### runTransaction
+```js
+store.firestore.runTransaction(t => {
+  return t.get(cityRef)
+      .then(doc => {
+        // Add one person to the city population
+        const newPopulation = doc.data().population + 1;
+        t.update(cityRef, { population: newPopulation });
+      });
+})
+.then(result => {
+  // TRANSACTION_SUCCESS action dispatched
+  console.log('Transaction success!');
+}).catch(err => {
+  // TRANSACTION_FAILURE action dispatched
+  console.log('Transaction failure:', err);
+});
 ```
 
 #### Types of Queries

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ export default connect((state) => ({
 }))(Todos)
 ```
 ### API
+The `store.firestore` instance created by the `reduxFirestore` enhancer extends [Firebase's JS API for Firestore](https://firebase.google.com/docs/reference/js/firebase.firestore). This means all of the methods regularly available through `firebase.firestore()` and the statics available from `firebase.firestore` are available. Certain methods (such as `get`, `set`, and `onSnapshot`) have a different API since they have been extended with action dispatching. The methods which have dispatch actions are listed below:
+
 #### Actions
 
 ##### get

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -364,6 +364,27 @@ export function unsetListeners(firebase, dispatch, listeners) {
   });
 }
 
+/**
+ * Atomic operation with Firestore (either read or write).
+ * @param {Object} firebase - Internal firebase object
+ * @param {Function} dispatch - Redux's dispatch function
+ * @param  {Function} transactionPromise - Function which runs transaction
+ * operation.
+ * @return {Promise} Resolves with result of transaction operation
+ */
+export function runTransaction(firebase, dispatch, transactionPromise) {
+  return wrapInDispatch(dispatch, {
+    ref: firebase.firestore,
+    method: 'runTransaction',
+    args: [transactionPromise],
+    types: [
+      actionTypes.TRANSACTION_START,
+      actionTypes.TRANSACTION_SUCCESS,
+      actionTypes.TRANSACTION_FAILURE,
+    ],
+  });
+}
+
 export default {
   get,
   firestoreRef,
@@ -373,4 +394,5 @@ export default {
   setListeners,
   unsetListener,
   unsetListeners,
+  runTransaction,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,9 @@ export const actionsPrefix = '@@reduxFirestore';
  * @property {String} ON_SNAPSHOT_REQUEST - `@@reduxFirestore/ON_SNAPSHOT_REQUEST`
  * @property {String} ON_SNAPSHOT_SUCCESS - `@@reduxFirestore/ON_SNAPSHOT_SUCCESS`
  * @property {String} ON_SNAPSHOT_FAILURE - `@@reduxFirestore/ON_SNAPSHOT_FAILURE`
+ * @property {String} TRANSACTION_START - `@@reduxFirestore/TRANSACTION_START`
+ * @property {String} TRANSACTION_SUCCESS - `@@reduxFirestore/TRANSACTION_SUCCESS`
+ * @property {String} TRANSACTION_FAILURE - `@@reduxFirestore/TRANSACTION_FAILURE`
  * @example
  * import { actionTypes } from 'react-redux-firebase'
  * actionTypes.SET === '@@reduxFirestore/SET' // true
@@ -75,6 +78,9 @@ export const actionTypes = {
   DOCUMENT_ADDED: `${actionsPrefix}/DOCUMENT_ADDED`,
   DOCUMENT_MODIFIED: `${actionsPrefix}/DOCUMENT_MODIFIED`,
   DOCUMENT_REMOVED: `${actionsPrefix}/DOCUMENT_REMOVED`,
+  TRANSACTION_START: `${actionsPrefix}/TRANSACTION_START`,
+  TRANSACTION_SUCCESS: `${actionsPrefix}/TRANSACTION_SUCCESS`,
+  TRANSACTION_FAILURE: `${actionsPrefix}/TRANSACTION_FAILURE`,
 };
 
 /**

--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -37,7 +37,7 @@ export default function createFirestoreInstance(firebase, configs, dispatch) {
   );
 
   return Object.assign(
-    firebase.firestore(),
+    firebase && firebase.firestore ? firebase.firestore() : {},
     firebase.firestore,
     { _: firebase._ },
     configs.helpersNamespace

--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -36,17 +36,13 @@ export default function createFirestoreInstance(firebase, configs, dispatch) {
     aliases,
   );
 
-  // Attach helpers to specified namespace
-  if (configs.helpersNamespace) {
-    return {
-      ...firebase,
-      ...firebase.firestore,
-      [configs.helpersNamespace]: methods,
-    };
-  }
-  return {
-    ...firebase,
-    ...firebase.firestore,
-    ...methods,
-  };
+  return Object.assign(
+    firebase.firestore(),
+    firebase.firestore,
+    { _: firebase._ },
+    configs.helpersNamespace
+      ? // Attach helpers to specified namespace
+        { [configs.helpersNamespace]: methods }
+      : methods,
+  );
 }

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -93,8 +93,8 @@ function writeCollection(collectionState, action) {
   }
 
   if (meta.doc && size(collectionState)) {
-    // Update item in array (handling storeAs)
-    return updateItemInArray(collectionState, meta.storeAs || meta.doc, item =>
+    // Update item in array
+    return updateItemInArray(collectionState, meta.doc, item =>
       mergeObjects(item, action.payload.ordered[0]),
     );
   }

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -23,7 +23,7 @@ function makePayload({ payload }, valToPass) {
  */
 export function wrapInDispatch(
   dispatch,
-  { ref, meta, method, args = [], types },
+  { ref, meta = {}, method, args = [], types },
 ) {
   const [requestingType, successType, errorType] = types;
   dispatch({

--- a/test/unit/enhancer.spec.js
+++ b/test/unit/enhancer.spec.js
@@ -5,7 +5,7 @@ const reducer = sinon.spy();
 const generateCreateStore = () =>
   compose(
     reduxFirestore(
-      {},
+      { firestore: () => ({ collection: () => ({}) }) },
       {
         userProfile: 'users',
       },
@@ -23,8 +23,12 @@ describe('enhancer', () => {
     expect(store).to.have.property('firestore');
   });
 
-  it('has the right methods', () => {
+  it('adds extended methods', () => {
     expect(store.firestore.setListener).to.be.a('function');
+  });
+
+  it('preserves unmodified internal Firebase methods', () => {
+    expect(store.firestore.collection).to.be.a('function');
   });
 });
 

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -254,6 +254,38 @@ describe('orderedReducer', () => {
           orderedData,
         );
       });
+
+      it('updates doc under storeAs', () => {
+        action = {
+          type: actionTypes.LISTENER_RESPONSE,
+          meta: {
+            collection: 'testing',
+            doc: '123abc',
+            storeAs: 'pathName',
+          },
+          payload: {
+            ordered: [
+              {
+                content: 'new',
+              },
+            ],
+          },
+          merge: {},
+        };
+
+        state = {
+          pathName: [
+            {
+              id: '123abc',
+              content: 'old',
+            },
+          ],
+        };
+        expect(orderedReducer(state, action)).to.have.nested.property(
+          `pathName.0.content`,
+          'new',
+        );
+      });
     });
 
     describe('GET_SUCCESS', () => {


### PR DESCRIPTION
### Description
* fix(orderedReducer): remove `storeAs` from `updateItemInArray` - #91
* feat(actions): `runTransaction` action added - #76
* feat(core): Firebase's Firestore internals (from `firebase.firestore()`) exposed for use of methods such as `batch` - #76 
* feat(tests): unit tests added for `oneListenerPerPath` option - #77

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #76
* #77
* #91
