### PR TITLE
docs(Config Options): rfConfig can be passed to reduxFirestore enhancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ import 'firebase/database'
 import 'firebase/firestore'
 
 const firebaseConfig = {} // from Firebase Console
+const rfConfig = {} // optional redux-firestore Config Options
 
 // Initialize firebase instance
 firebase.initializeApp(firebaseConfig)
@@ -52,7 +53,7 @@ firebase.firestore();
 
 // Add reduxFirestore store enhancer to store creator
 const createStoreWithFirebase = compose(
-  reduxFirestore(firebase), // firebase instance as first argument
+  reduxFirestore(firebase, rfConfig), // firebase instance as first argument, rfConfig as optional second
 )(createStore)
 
 // Add Firebase to reducers
@@ -453,6 +454,7 @@ export default enhance(SomeComponent)
 ```
 
 ## Config Options
+Optional configuration options for redux-firestore, provided to reduxFirestore enhancer as optional second argument. Combine any of them together in an object.
 
 #### logListenerError
 Default: `true`


### PR DESCRIPTION
### Description
Explained in the readme that the config options can be passed to reduxFirestore enhancer as optional second argument.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
