### PR TITLE
Fix for disappearing `composite` slice

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -30,6 +30,7 @@ const combinedReducers = combineReducers({
   listeners: listenersReducer,
   errors: errorsReducer,
   queries: queriesReducer,
+  composite: state => state, // mock reducer to retain info created by cross slice reducer
 });
 
 export default reduceReducers(combinedReducers, crossSliceReducer);

--- a/src/reducers/crossSliceReducer.js
+++ b/src/reducers/crossSliceReducer.js
@@ -1,26 +1,18 @@
 /* eslint-disable guard-for-in, no-restricted-syntax, no-param-reassign */
 
 import produce from 'immer';
-import { values, groupBy, merge, set } from 'lodash';
+import { values, groupBy, merge, set, get } from 'lodash';
 import { actionTypes } from '../constants';
-import { isComposable } from './queriesReducer';
 
 export default function crossSliceReducer(state = {}, action) {
-  // Only relevant for queries
-  if (!isComposable(action)) {
-    return state;
-  }
-
   return produce(state, draft => {
     switch (action.type) {
-      case actionTypes.GET_SUCCESS:
-      case actionTypes.DELETE_SUCCESS:
       case actionTypes.DOCUMENT_MODIFIED:
       case actionTypes.DOCUMENT_ADDED:
       case actionTypes.DOCUMENT_REMOVED:
       case actionTypes.LISTENER_RESPONSE:
       case actionTypes.UNSET_LISTENER:
-        // Take all of the composite values and plop them into data, replacing the existing data entirely
+        // Take all of the query values and plop them into composite, replacing the existing data entirely
         const groups = groupBy(
           values(state.queries),
           c => c.storeAs || c.collection,
@@ -29,7 +21,7 @@ export default function crossSliceReducer(state = {}, action) {
         for (const storeAs in groups) {
           const updated = {};
           for (const item of groups[storeAs]) {
-            merge(updated, item.data || {});
+            merge(updated, get(item, 'data', {}));
           }
           set(draft, ['composite', storeAs], updated);
         }

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console, import/prefer-default-export */
 
-export function display(obj) {
-  console.log(JSON.stringify(obj, null, 2));
+export function display(obj, message = '') {
+  console.log(message, JSON.stringify(obj, null, 2));
 }

--- a/test/unit/reducers/reducer.spec.js
+++ b/test/unit/reducers/reducer.spec.js
@@ -9,6 +9,39 @@ const initialState = {
 
 describe('reducer', () => {
   describe('cross slice behaviour', () => {
+    it('keeps composite when SET_LISTENER is passed', () => {
+      const doc1 = { key1: 'value1', id: 'testDocId1' }; // initial doc
+      const doc2 = { key1: 'value1', id: 'testDocId2' }; // added doc
+
+      // Initial seed
+      const action1 = {
+        meta: {
+          collection: 'testCollection',
+          storeAs: 'testStoreAs',
+          where: ['abc', '===', 123],
+        },
+        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        type: actionTypes.LISTENER_RESPONSE,
+      };
+      const action2 = {
+        type: actionTypes.GET_REQUEST,
+        meta: {
+          collection: 'testCollection',
+          doc: doc2.id,
+        },
+        payload: {
+          args: [],
+        },
+      };
+
+      const pass1 = reducer(initialState, action1);
+      const pass2 = reducer(pass1, action2);
+      expect(pass1.composite.testStoreAs[doc1.id]).to.eql(doc1);
+      expect(pass2.composite.testStoreAs[doc1.id]).to.eql(doc1);
+      const pass3 = reducer(pass2, { type: 'some other type' });
+      expect(pass3.composite.testStoreAs[doc1.id]).to.eql(doc1);
+    });
+
     it('handles adds', () => {
       const doc1 = { key1: 'value1', id: 'testDocId1' }; // initial doc
       const doc2 = { key1: 'value1', id: 'testDocId2' }; // added doc


### PR DESCRIPTION
### Description
Since the cross slice reducer adds a slice, it doesn't exist when the other slices finish running.  If a non-impactful action is passed to the cross slice reducer and it decides it doesn't need to regenerate the composites, it will simply return `state` ... without a `composite` slice on it!

To fix this, a mock reducer has been added to `combinedReducers` that will retain state in that composed slice.

### Check List
- [Y ] All tests passing
- [ N/A] Docs updated with any changes or examples if applicable
- [ Y] Added tests to ensure new feature(s) work properly
