### PR TITLE
fix(typings): make otherConfig optional for enhancer in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,12 +85,12 @@ export const constants: {
  * A redux store enhancer that adds store.firebase (passed to React component
  * context through react-redux's <Provider>).
  */
-export function reduxFirestore(firebaseInstance: object, otherConfig: object): any;
+export function reduxFirestore(firebaseInstance: object, otherConfig?: object): any;
 
 /**
  * Get extended firestore instance (attached to store.firestore)
  */
-export function getFirestore(firebaseInstance: object, otherConfig: object): any;
+export function getFirestore(firebaseInstance: object, otherConfig?: object): any;
 
 /**
  * A redux store reducer for Firestore state


### PR DESCRIPTION
### Description
This returns a typescript error
```typescript
reduxFirestore(firebase)
```

```typescript
[ts] Expected 2 arguments, but got 1.
(alias) reduxFirestore(firebaseInstance: object, otherConfig: object): any
import reduxFirestore
A redux store enhancer that adds store.firebase (passed to React component context through react-redux's <Provider>).
```

Returns an error if the `otherConfig` attribute isn't passed.

According to the [README](https://github.com/prescottprue/redux-firestore/blame/master/README.md#L47) the second argument is optional. 

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
