### PR TITLE
fix(orderedReducer): CLEAR_DATA action correctly clears ordered state for actions dispatched without meta

### DIFF
--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -230,12 +230,8 @@ const orderedCollectionReducer = createReducer(undefined, actionHandlers);
  * @return {Object} Ordered state after reduction
  */
 export default function orderedReducer(state = {}, action) {
-  // Return state if action is malformed (i.e. no type, or valid meta)
-  if (
-    !action.type ||
-    !action.meta ||
-    (!action.meta.storeAs && !action.meta.collection)
-  ) {
+  // Return state if action is malformed (i.e. no type)
+  if (!action.type) {
     return state;
   }
 
@@ -250,6 +246,11 @@ export default function orderedReducer(state = {}, action) {
 
   // Return original state if action type is not within actionHandlers
   if (!Object.prototype.hasOwnProperty.call(actionHandlers, action.type)) {
+    return state;
+  }
+
+  // Return state if action does not contain valid meta
+  if (!action.meta && !action.meta.storeAs && !action.meta.collection) {
     return state;
   }
 

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -250,7 +250,7 @@ export default function orderedReducer(state = {}, action) {
   }
 
   // Return state if action does not contain valid meta
-  if (!action.meta && !action.meta.storeAs && !action.meta.collection) {
+  if (!action.meta || (!action.meta.storeAs && !action.meta.collection)) {
     return state;
   }
 

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -587,17 +587,14 @@ describe('orderedReducer', () => {
       it('removes all data from state', () => {
         action = {
           type: actionTypes.CLEAR_DATA,
-          meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
         };
-        state = {};
-        expect(orderedReducer(state, action)).to.be.empty;
+        state = { some: [{ id: 'thing' }] };
         expect(orderedReducer(state, action)).to.be.empty;
       });
 
       it('sets a new reference when clearing', () => {
         action = {
           type: actionTypes.CLEAR_DATA,
-          meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
         };
         state = {};
         expect(orderedReducer(state, action)).to.not.equal(state);
@@ -606,9 +603,7 @@ describe('orderedReducer', () => {
       describe('preserve parameter', () => {
         it('array saves keys from state', () => {
           action = {
-            meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
             type: actionTypes.CLEAR_DATA,
-            payload: {},
             preserve: { ordered: ['some'] },
           };
           state = { some: 'value' };
@@ -617,9 +612,7 @@ describe('orderedReducer', () => {
 
         it('function returns state to save', () => {
           action = {
-            meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
             type: actionTypes.CLEAR_DATA,
-            payload: {},
             preserve: { ordered: currentState => currentState },
           };
           state = { some: 'value' };


### PR DESCRIPTION
### Description
* fix(orderedReducer): `CLEAR_DATA` action correctly clears `ordered` state for actions dispatched without meta - #114
* fix(tests): update orderedReducer tests to include case of `CLEAR_DATA` action dispatched without `meta` - #114

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
 * #114
