### PR TITLE
v0.5.8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,12 +85,12 @@ export const constants: {
  * A redux store enhancer that adds store.firebase (passed to React component
  * context through react-redux's <Provider>).
  */
-export function reduxFirestore(firebaseInstance: object, otherConfig: object): any;
+export function reduxFirestore(firebaseInstance: object, otherConfig?: object): any;
 
 /**
  * Get extended firestore instance (attached to store.firestore)
  */
-export function getFirestore(firebaseInstance: object, otherConfig: object): any;
+export function getFirestore(firebaseInstance: object, otherConfig?: object): any;
 
 /**
  * A redux store reducer for Firestore state

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -230,12 +230,8 @@ const orderedCollectionReducer = createReducer(undefined, actionHandlers);
  * @return {Object} Ordered state after reduction
  */
 export default function orderedReducer(state = {}, action) {
-  // Return state if action is malformed (i.e. no type, or valid meta)
-  if (
-    !action.type ||
-    !action.meta ||
-    (!action.meta.storeAs && !action.meta.collection)
-  ) {
+  // Return state if action is malformed (i.e. no type)
+  if (!action.type) {
     return state;
   }
 
@@ -250,6 +246,11 @@ export default function orderedReducer(state = {}, action) {
 
   // Return original state if action type is not within actionHandlers
   if (!Object.prototype.hasOwnProperty.call(actionHandlers, action.type)) {
+    return state;
+  }
+
+  // Return state if action does not contain valid meta
+  if (!action.meta || (!action.meta.storeAs && !action.meta.collection)) {
     return state;
   }
 

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -587,17 +587,14 @@ describe('orderedReducer', () => {
       it('removes all data from state', () => {
         action = {
           type: actionTypes.CLEAR_DATA,
-          meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
         };
-        state = {};
-        expect(orderedReducer(state, action)).to.be.empty;
+        state = { some: [{ id: 'thing' }] };
         expect(orderedReducer(state, action)).to.be.empty;
       });
 
       it('sets a new reference when clearing', () => {
         action = {
           type: actionTypes.CLEAR_DATA,
-          meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
         };
         state = {};
         expect(orderedReducer(state, action)).to.not.equal(state);
@@ -606,9 +603,7 @@ describe('orderedReducer', () => {
       describe('preserve parameter', () => {
         it('array saves keys from state', () => {
           action = {
-            meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
             type: actionTypes.CLEAR_DATA,
-            payload: {},
             preserve: { ordered: ['some'] },
           };
           state = { some: 'value' };
@@ -617,9 +612,7 @@ describe('orderedReducer', () => {
 
         it('function returns state to save', () => {
           action = {
-            meta: { collection: 'testing' }, // meta is required to trigger ordered reducer
             type: actionTypes.CLEAR_DATA,
-            payload: {},
             preserve: { ordered: currentState => currentState },
           };
           state = { some: 'value' };


### PR DESCRIPTION
### Description
* fix(orderedReducer): `CLEAR_DATA` action correctly clears `ordered` state for actions dispatched without meta - #114
* fix(tests): update orderedReducer tests to include case of `CLEAR_DATA` action dispatched without `meta` - #114
* fix(typings): make `otherConfig` optional for `reduxFirestore` (store enhancer) in typings - @am17torres

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #114
