### PR TITLE
v1.0.0-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,11 @@ deploy:
     on:
       node: '10'
       branch: 'next'
+  - provider: npm
+    skip_cleanup: true
+    email: $NPM_EMAIL
+    api_key: $NPM_TOKEN
+    tag: alpha
+    on:
+      node: '10'
+      branch: 'alpha'

--- a/examples/complete/src/routes/Home/components/Home/Home.js
+++ b/examples/complete/src/routes/Home/components/Home/Home.js
@@ -4,6 +4,7 @@ import Theme from 'theme'
 import { connect } from 'react-redux'
 import { compose, lifecycle, withHandlers } from 'recompose'
 import { withFirestore } from 'react-redux-firebase'
+import { firestoreOrderedSelector } from 'redux-firestore'
 import { withStore } from 'utils/components'
 import classes from './Home.scss'
 
@@ -15,7 +16,7 @@ const Home = ({ todos }) => (
       <h2>Home Route</h2>
     </div>
     <div>
-      {todos.map((todo, i) => (
+      {todos && todos.map && todos.map((todo, i) => (
         <div key={`${todo.id}-${i}`}>{JSON.stringify(todo)}</div>
       ))}
     </div>
@@ -25,6 +26,30 @@ const Home = ({ todos }) => (
 Home.propTypes = {
   todos: PropTypes.array
 }
+
+// Function which returns todos query config
+function getTodosQuery() {
+  return {
+    collection: 'todos',
+    limit: 10
+  }
+}
+
+// Function which returns todos query config
+function getTodoEventsQuery(props) {
+  if (!props.todoId) {
+    console.error('todoId is required to create todo events query, check component props')
+    return
+  }
+  return {
+    collection: 'todos',
+    doc: props.todoId,
+    limit: 10,
+    subcollections: [{ collection: 'events' }]
+  }
+}
+
+const selector = firestoreOrderedSelector(getTodosQuery())
 
 const enhance = compose(
   withStore,
@@ -39,12 +64,12 @@ const enhance = compose(
   }),
   lifecycle({
     componentWillMount() {
-      this.props.loadCollection('todos')
+      this.props.loadCollection(getTodosQuery())
     }
   }),
-  connect(({ firestore, firebase }) => ({
-    todos: firestore.ordered.todos || [],
-    uid: firebase.auth.uid
+  connect((state, props) => ({
+    todos: selector(state),
+    uid: state.firebase.auth.uid
   }))
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.6.0-alpha.2",
+  "version": "1.0.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.6.0-alpha.2",
+  "version": "1.0.0-alpha",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import { firestoreActions } from './actions';
 import createFirestoreInstance from './createFirestoreInstance';
 import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
+import { getQueryName } from './utils/query';
+import { firestoreOrderedSelector, firestoreDataSelector } from './selectors';
 
 // converted with transform-inline-environment-variables
 export const version = process.env.npm_package_version;
@@ -15,6 +17,9 @@ export {
   enhancer as reduxFirestore,
   createFirestoreInstance,
   firestoreActions as actions,
+  getQueryName,
+  firestoreOrderedSelector,
+  firestoreDataSelector,
   getFirestore,
   constants,
   actionTypes,

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -1,4 +1,4 @@
-import { get, last } from 'lodash';
+import { get, last, dropRight } from 'lodash';
 import { setWith, assign } from 'lodash/fp';
 import { actionTypes } from '../constants';
 import { getQueryName } from '../utils/query';
@@ -41,6 +41,14 @@ export default function dataReducer(state = {}, action) {
       const queryName = getQueryName(meta, { onlySubcollections: true });
       // Get previous data at path to check for existence
       const previousData = get(state, meta.storeAs || queryName);
+      if (meta.subcollections) {
+        const setPath =
+          queryName.split('/').length % 2
+            ? getQueryName(meta)
+            : dropRight(pathToArr(queryName)).join('/');
+        // Set data to state immutabily (lodash/fp's setWith creates copy)
+        return setWith(Object, setPath, payload.data, state);
+      }
       // Set data (without merging) if no previous data exists or if there are subcollections
       if (!previousData || meta.subcollections) {
         // Set data to state immutabily (lodash/fp's setWith creates copy)

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -140,10 +140,17 @@ function getStoreUnderKey(action) {
   if (action.meta.oldStoreAs) {
     return action.meta.storeAs || action.meta.collection;
   }
-  const pathArr = pathToArr(getQueryName(action.meta));
+  const queryName = getQueryName(action.meta);
+  // Query contains other query params, store under full queryName
+  if (queryName.includes('?')) {
+    return queryName;
+  }
+  const pathArr = pathToArr(queryName);
+  // Return top level key if path is not multiple "/"
   if (pathArr.length <= '1') {
     return action.meta.storeAs || action.meta.collection;
   }
+  // Remove last / from path
   return dropRight(pathArr).join('/');
 }
 

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -1,4 +1,13 @@
-import { size, get, reject, dropRight, map, keyBy, isEqual } from 'lodash';
+import {
+  size,
+  get,
+  reject,
+  dropRight,
+  map,
+  keyBy,
+  isEqual,
+  last,
+} from 'lodash';
 import { assign as assignObjects, merge as mergeObjects } from 'lodash/fp';
 import { actionTypes } from '../constants';
 import { getQueryName } from '../utils/query';
@@ -42,9 +51,10 @@ function modifyDoc(collectionState, action) {
  */
 function addDoc(array = [], action) {
   const { meta, payload } = action;
+  const id = last(pathToArr(getQueryName(meta)));
   return [
     ...array.slice(0, payload.ordered.newIndex),
-    { id: meta.doc, ...payload.data },
+    { id, ...payload.data },
     ...array.slice(payload.ordered.newIndex),
   ];
 }
@@ -56,8 +66,9 @@ function addDoc(array = [], action) {
  * @return {Array} State with document modified
  */
 function removeDoc(array, action) {
+  const id = last(pathToArr(getQueryName(action.meta)));
   // Remove doc from collection array
-  return reject(array, { id: action.meta.doc }); // returns a new array
+  return reject(array, { id }); // returns a new array
 }
 
 /**
@@ -180,9 +191,7 @@ export default function orderedReducer(state = {}, action) {
     return state;
   }
 
-  const storeUnderKey = !action.meta.oldStoreAs
-    ? getStoreUnderKey(action)
-    : action.meta.storeAs || action.meta.collection;
+  const storeUnderKey = getStoreUnderKey(action);
   const collectionStateSlice = state[storeUnderKey];
   return {
     ...state,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,30 @@
+import { get } from 'lodash';
+import { getQueryName } from './utils/query';
+
+/**
+ * Create state value selector for firestore data by key
+ * @param {Object|String} queryConfig - Configuration for query
+ */
+export function firestoreDataSelector(queryConfig) {
+  return (state, getPath) => {
+    const queryName = getQueryName(queryConfig, { onlySubcollections: true });
+    if (!getPath) {
+      return state.firestore.data[queryName];
+    }
+    return get(state.firestore.data[queryName], getPath);
+  };
+}
+
+/**
+ * Create state value selector for firestore ordered data (array)
+ * @param {Object|String} queryConfig - Configuration for query
+ */
+export function firestoreOrderedSelector(queryConfig) {
+  return (state, getPath) => {
+    const queryName = getQueryName(queryConfig);
+    if (!getPath) {
+      return state.firestore.ordered[queryName];
+    }
+    return get(state.firestore.ordered[queryName], getPath);
+  };
+}

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -154,9 +154,11 @@ function whereToStr(where) {
  * @param  {String} meta.collection - Collection name of query
  * @param  {String} meta.doc - Document id of query
  * @param  {Array} meta.subcollections - Subcollections of query
+ * @param {Object} [options={}] - Options object
+ * @param {Boolean} [options.onlySubcollections=false] - Options object
  * @return {String} String representing query settings
  */
-export function getQueryName(meta) {
+export function getQueryName(meta, options = {}) {
   if (isString(meta)) {
     return meta;
   }
@@ -174,6 +176,13 @@ export function getQueryName(meta) {
     );
     basePath = `${basePath}/${mappedCollections.join('/')}`;
   }
+  const { onlySubcollections } = options || {};
+
+  // Return path only including subcollections (data)
+  if (onlySubcollections) {
+    return basePath;
+  }
+
   if (where) {
     if (!isArray(where)) {
       throw new Error('where parameter must be an array.');

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -167,6 +167,11 @@ export function getQueryName(meta, options = {}) {
     throw new Error('Collection is required to build query name');
   }
   let basePath = collection;
+  const { onlySubcollections } = options || {};
+  // Return path only including subcollections (data)
+  if (onlySubcollections && !subcollections) {
+    return basePath;
+  }
   if (doc) {
     basePath = basePath.concat(`/${doc}`);
   }
@@ -176,7 +181,6 @@ export function getQueryName(meta, options = {}) {
     );
     basePath = `${basePath}/${mappedCollections.join('/')}`;
   }
-  const { onlySubcollections } = options || {};
 
   // Return path only including subcollections (data)
   if (onlySubcollections) {

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -156,6 +156,7 @@ function whereToStr(where) {
  * @param  {Array} meta.subcollections - Subcollections of query
  * @param {Object} [options={}] - Options object
  * @param {Boolean} [options.onlySubcollections=false] - Options object
+ * @param {Boolean} [options.withDoc=false] - Options object
  * @return {String} String representing query settings
  */
 export function getQueryName(meta, options = {}) {

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -162,7 +162,10 @@ export function getQueryName(meta, options = {}) {
   if (isString(meta)) {
     return meta;
   }
-  const { collection, doc, subcollections, where, limit } = meta;
+  const { collection, doc, subcollections, where, limit, storeAs } = meta;
+  if (storeAs) {
+    return storeAs;
+  }
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -13,7 +13,7 @@ import {
  * @return {Array} Path as Array
  * @private
  */
-function pathToArr(path) {
+export function pathToArr(path) {
   return path ? path.split(/\//).filter(p => !!p) : [];
 }
 

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -13,7 +13,7 @@ import {
  * @return {Array} Path as Array
  * @private
  */
-export function pathToArr(path) {
+function pathToArr(path) {
   return path ? path.split(/\//).filter(p => !!p) : [];
 }
 
@@ -55,46 +55,6 @@ export function combineReducers(reducers) {
       /* eslint-enable no-param-reassign */
       return nextState;
     }, {});
-}
-
-/**
- * Get path from meta data. Path is used with lodash's setWith to set deep
- * data within reducers.
- * @param  {Object} meta - Action meta data object
- * @param  {String} meta.collection - Name of Collection for which the action
- * is to be handled.
- * @param  {String} meta.doc - Name of Document for which the action is to be
- * handled.
- * @param  {Array} meta.subcollections - Subcollections of data
- * @param  {String} meta.storeAs - Another key within redux store that the
- * action associates with (used for storing data under a path different
- * from its collection/document)
- * @return {String} String path to be used within reducer
- * @private
- */
-export function pathFromMeta(meta) {
-  if (!meta) {
-    throw new Error('Action meta is required to build path for reducers.');
-  }
-  const { collection, doc, subcollections, storeAs } = meta;
-  if (storeAs) {
-    return doc ? `${storeAs}.${doc}` : storeAs;
-  }
-  if (meta.path) {
-    return meta.path.split('/');
-  }
-  if (!collection) {
-    throw new Error('Collection is required to construct reducer path.');
-  }
-  let basePath = collection;
-  if (doc) {
-    basePath += `.${doc}`;
-  }
-  if (!subcollections) {
-    return basePath;
-  }
-  const mappedCollections = subcollections.map(pathFromMeta);
-  return basePath.concat(`.${mappedCollections.join('.')}`);
 }
 
 /**

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -69,6 +69,9 @@ export function combineReducers(reducers) {
  */
 export function updateItemInArray(array, itemId, updateItemCallback) {
   let matchFound = false;
+  if (!array || !array.length) {
+    return [];
+  }
   const modified = array.map(item => {
     // Preserve items that do not have matching ids
     if (!item || item.id !== itemId) {

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -30,12 +30,10 @@ describe('dataReducer', () => {
       it('throws for no collection', () => {
         const someDoc = {};
         payload = { data: { abc: someDoc } };
-        meta = { collection, doc };
+        meta = {};
         action = { meta, payload, type: actionTypes.DOCUMENT_ADDED };
-        result = dataReducer({}, action);
-        expect(result).to.have.nested.property(
-          `${collection}.${doc}.abc`,
-          someDoc,
+        expect(() => dataReducer({}, action)).to.throw(
+          'Collection is required to build query name',
         );
       });
     });
@@ -64,7 +62,7 @@ describe('dataReducer', () => {
         meta = {};
         action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
         expect(() => dataReducer(state, action)).to.throw(
-          'Collection is required to construct reducer path.',
+          'Collection is required to build query name',
         );
       });
 
@@ -104,8 +102,8 @@ describe('dataReducer', () => {
             subcollections: [{ collection: 'another' }],
           };
           action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
-          expect(dataReducer(state, action)).to.have.nested.property(
-            'test.someDoc.another',
+          expect(dataReducer(state, action)).to.have.property(
+            'test/someDoc/another',
             data,
           );
         });
@@ -181,7 +179,7 @@ describe('dataReducer', () => {
         meta = {};
         action = { meta, payload, type: actionTypes.GET_SUCCESS };
         expect(() => dataReducer(state, action)).to.throw(
-          'Collection is required to construct reducer path.',
+          'Collection is required to build query name',
         );
       });
 
@@ -319,7 +317,7 @@ describe('dataReducer', () => {
         payload = {};
         action = { meta: {}, payload, type: actionTypes.LISTENER_ERROR };
         expect(() => dataReducer(state, action)).to.throw(
-          'Collection is required to construct reducer path.',
+          'Collection is required to build query name',
         );
       });
 

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -100,64 +100,68 @@ describe('dataReducer', () => {
         it('updates empty state', () => {
           const data = { abc: { field: 'test' } };
           payload = { data };
+          const subcollection = { collection: 'another' };
           meta = {
             collection,
             doc: 'someDoc',
-            subcollections: [{ collection: 'another' }],
+            subcollections: [subcollection],
           };
           action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
-          expect(dataReducer(state, action)).to.have.property(
-            'test/someDoc/another',
-            data,
-          );
+          result = dataReducer(state, action);
+          expect(
+            result[`test/someDoc/${subcollection.collection}`],
+          ).to.have.property('abc', data.abc);
         });
 
         it('updates state when data already exists', () => {
           const data = { testing: { field: 'test' } };
           payload = { data };
+          const subcollection = { collection: 'another', doc: 'testing' };
           meta = {
             collection,
             doc: 'someDoc',
-            subcollections: [{ collection: 'another', doc: 'testing' }],
+            subcollections: [subcollection],
           };
+          const subcollectionPath = `${collection}/someDoc/${
+            subcollection.collection
+          }`;
           const existingState = {
-            test: { someDoc: { another: { testing: {} } } },
+            [subcollectionPath]: { original: 'data' },
           };
           action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
           result = dataReducer(existingState, action);
-          // console.log('------updates state', result);
-          expect(result['test/someDoc/another/testing']).to.have.property(
-            'field',
+          expect(result[subcollectionPath]).to.have.nested.property(
+            `${subcollection.doc}.field`,
             data.testing.field,
           );
         });
 
-        describe('containing multiple subcollections', () => {
-          it('updates state when data already exists', () => {
-            const data = {
-              subdoc2: { field: 'test' },
-            };
-            payload = { data };
-            meta = {
-              collection,
-              doc: 'someDoc',
-              subcollections: [
-                { collection: 'subcol1', doc: 'subdoc1' },
-                { collection: 'subcol2', doc: 'subdoc2' },
-              ],
-            };
-            const existingState = {
-              test: {
-                someDoc: { subcol1: { subdoc1: { subcol2: { subdoc2: {} } } } },
-              },
-            };
-            action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
-            result = dataReducer(existingState, action);
-            // console.log('------subcollection update', result);
-            expect(
-              result['test/someDoc/subcol1/subdoc1/subcol2/subdoc2'],
-            ).to.have.property('field', data.subdoc2.field);
-          });
+        it('updates deep subcollection doc when state data already exists', () => {
+          const subcollection1 = { collection: 'subcol1', doc: 'subdoc1' };
+          const subcollection2 = { collection: 'subcol2', doc: 'subdoc2' };
+          const data = {
+            [subcollection2.doc]: { field: 'test' },
+          };
+          payload = { data };
+          meta = {
+            collection,
+            doc,
+            subcollections: [subcollection1, subcollection2],
+          };
+          const subPath = `${collection}/${doc}/${subcollection1.collection}/${
+            subcollection1.doc
+          }/${subcollection2.collection}`;
+          const existingState = {
+            [subPath]: {
+              [subcollection2.doc]: { original: 'data' },
+            },
+          };
+          action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
+          result = dataReducer(existingState, action);
+          expect(result[subPath]).to.have.nested.property(
+            `${subcollection2.doc}.field`,
+            data.subdoc2.field,
+          );
         });
       });
     });
@@ -222,18 +226,21 @@ describe('dataReducer', () => {
         it('updates state when data already exists', () => {
           const data = { testing: { field: 'test' } };
           payload = { data };
+          const subcollection = { collection: 'another', doc: 'testing' };
           meta = {
             collection,
             doc: 'someDoc',
-            subcollections: [{ collection: 'another', doc: 'testing' }],
+            subcollections: [subcollection],
           };
           const existingState = {
             test: { someDoc: { another: { testing: {} } } },
           };
           action = { meta, payload, type: actionTypes.GET_SUCCESS };
           result = dataReducer(existingState, action);
-          expect(result['test/someDoc/another/testing']).to.have.property(
-            'field',
+          expect(
+            result[`test/someDoc/${subcollection.collection}`],
+          ).to.have.nested.property(
+            `${subcollection.doc}.field`,
             data.testing.field,
           );
         });

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -66,7 +66,7 @@ describe('dataReducer', () => {
         );
       });
 
-      it('merges new state with existing state', () => {
+      it('replaces existing doc params with new doc params', () => {
         const data = { [doc]: { newData: { field: 'test' } } };
         payload = { data };
         meta = {
@@ -82,11 +82,15 @@ describe('dataReducer', () => {
           type: actionTypes.LISTENER_RESPONSE,
         };
         result = dataReducer(existingState, action);
+
+        // Contains new data
         expect(result).to.have.nested.property(
           `${collection}.${doc}.newData.field`,
           data[doc].newData.field,
         );
-        expect(result).to.have.nested.property(
+
+        // Does not have original data
+        expect(result).to.not.have.nested.property(
           `${collection}.${doc}.originalData.some.val`,
           existingState[collection][doc].originalData.some.val,
         );
@@ -120,8 +124,10 @@ describe('dataReducer', () => {
             test: { someDoc: { another: { testing: {} } } },
           };
           action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
-          expect(dataReducer(existingState, action)).to.have.nested.property(
-            'test.someDoc.another.testing.field',
+          result = dataReducer(existingState, action);
+          // console.log('------updates state', result);
+          expect(result['test/someDoc/another/testing']).to.have.property(
+            'field',
             data.testing.field,
           );
         });
@@ -146,10 +152,11 @@ describe('dataReducer', () => {
               },
             };
             action = { meta, payload, type: actionTypes.LISTENER_RESPONSE };
-            expect(dataReducer(existingState, action)).to.have.nested.property(
-              'test.someDoc.subcol1.subdoc1.subcol2.subdoc2.field',
-              data.subdoc2.field,
-            );
+            result = dataReducer(existingState, action);
+            // console.log('------subcollection update', result);
+            expect(
+              result['test/someDoc/subcol1/subdoc1/subcol2/subdoc2'],
+            ).to.have.property('field', data.subdoc2.field);
           });
         });
       });
@@ -207,7 +214,7 @@ describe('dataReducer', () => {
           };
           action = { meta, payload, type: actionTypes.GET_SUCCESS };
           expect(dataReducer(state, action)).to.have.nested.property(
-            'test.someDoc.another',
+            'test/someDoc/another',
             data,
           );
         });
@@ -225,7 +232,7 @@ describe('dataReducer', () => {
           };
           action = { meta, payload, type: actionTypes.GET_SUCCESS };
           expect(dataReducer(existingState, action)).to.have.nested.property(
-            'test.someDoc.another.testing.field',
+            'test/someDoc/another/testing.field',
             data.testing.field,
           );
         });

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -231,8 +231,9 @@ describe('dataReducer', () => {
             test: { someDoc: { another: { testing: {} } } },
           };
           action = { meta, payload, type: actionTypes.GET_SUCCESS };
-          expect(dataReducer(existingState, action)).to.have.nested.property(
-            'test/someDoc/another/testing.field',
+          result = dataReducer(existingState, action);
+          expect(result['test/someDoc/another/testing']).to.have.property(
+            'field',
             data.testing.field,
           );
         });
@@ -262,9 +263,11 @@ describe('dataReducer', () => {
       it('clears data from state', () => {
         meta = { collection, doc };
         action = { meta, type: actionTypes.DELETE_SUCCESS };
-        expect(
-          dataReducer({ [collection]: { [doc]: { thing: 'asdf' } } }, action),
-        ).to.have.nested.property(`${collection}.${doc}`, null);
+        result = dataReducer(
+          { [collection]: { [doc]: { thing: 'asdf' } } },
+          action,
+        );
+        expect(result).to.have.nested.property(`${collection}.${doc}`, null);
       });
 
       it('preserves keys provided in preserve parameter', () => {

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -208,8 +208,11 @@ describe('orderedReducer', () => {
           subcollections: [subDocSetting],
         };
         action = { meta, payload, type: actionTypes.DELETE_SUCCESS };
+        const slashPath = `${collection}/${doc}/${subDocSetting.collection}/${
+          subDocSetting.doc
+        }`;
         const result = orderedReducer(
-          { [collection]: [someDoc, someDoc2] },
+          { [slashPath]: [someDoc, someDoc2] },
           action,
         );
         // Confirm first item is still original doc
@@ -218,9 +221,9 @@ describe('orderedReducer', () => {
           someDoc.id,
         );
         // Confirm other item at top level is preserved
-        expect(result[collection]).to.have.length(2);
+        expect(result[slashPath]).to.have.length(2);
         // Removes property in original data
-        expect(result).to.not.have.nested.property(
+        expect(result[slashPath]).to.not.have.nested.property(
           `${collection}.0.subtest.0.id`,
           subDocSetting.doc,
         );
@@ -429,12 +432,13 @@ describe('orderedReducer', () => {
           state = { testing: [{ id: 'doc', another: 'thing' }] };
           const result = orderedReducer(state, action);
           // Adds subcollection to document
-          expect(result).to.have.nested.property(
-            `testing.0.${subcollection.collection}.0.id`,
-            orderedData.id,
-          );
+          expect(
+            result[`testing/doc/${subcollection.collection}`],
+          ).to.have.property('0.id', orderedData.id);
           // Preserves original value
-          expect(result).to.have.nested.property('testing.0.another', 'thing');
+          expect(
+            result[`testing/doc/${subcollection.collection}`],
+          ).to.have.property('another', 'thing');
         });
 
         it('perserves existing collections on doc updates', () => {

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -60,7 +60,7 @@ describe('orderedReducer', () => {
         const meta = {
           collection,
           doc,
-          subcollections: [{ collection: subcollection }],
+          subcollections: [{ collection: subcollection, doc: subdoc }],
           path: `${collection}/${doc}/${subcollection}/${subdoc}`,
         };
         action = {
@@ -69,14 +69,12 @@ describe('orderedReducer', () => {
           type: actionTypes.DOCUMENT_ADDED,
         };
         const result = orderedReducer({}, action);
+        const parentPath = `${collection}/${doc}/${subcollection}`;
         // Id is set
-        expect(result).to.have.nested.property(
-          `${collection}.0.${subcollection}.0.id`,
-          subdoc,
-        );
+        expect(result[parentPath]).to.have.nested.property('0.id', subdoc);
         // Value is set
-        expect(result).to.have.nested.property(
-          `${collection}.0.${subcollection}.0.some`,
+        expect(result[parentPath]).to.have.nested.property(
+          '0.some',
           fakeDoc.some,
         );
       });
@@ -123,11 +121,12 @@ describe('orderedReducer', () => {
           { [collection]: [someDoc, someDoc2] },
           action,
         );
-        // Confirm first item is
+        // Confirm first item is second doc
         expect(result).to.have.nested.property(
           `${collection}.0.id`,
           someDoc2.id,
         );
+        // Confirm first item is second doc
         expect(result[collection]).to.have.length(1);
       });
 
@@ -212,7 +211,7 @@ describe('orderedReducer', () => {
           subDocSetting.doc
         }`;
         const result = orderedReducer(
-          { [slashPath]: [someDoc, someDoc2] },
+          { [collection]: [someDoc], [slashPath]: [someDoc, someDoc2] },
           action,
         );
         // Confirm first item is still original doc
@@ -400,18 +399,21 @@ describe('orderedReducer', () => {
         it('adds a new doc within state with subcollection', () => {
           const orderedData = { id: 'subDoc' };
           const subcollection = { collection: 'testing2' };
+          const collection = 'testing';
+          const doc = 'doc';
           action = {
             meta: {
-              collection: 'testing',
-              doc: 'doc',
+              collection,
+              doc,
               subcollections: [subcollection],
             },
             type: actionTypes.LISTENER_RESPONSE,
             payload: { ordered: [orderedData] },
           };
           state = {};
-          expect(orderedReducer(state, action)).to.have.nested.property(
-            `testing.0.${subcollection.collection}.0.id`,
+          const result = orderedReducer(state, action);
+          expect(result[`${collection}/${doc}`]).to.have.nested.property(
+            '0.id',
             orderedData.id,
           );
         });
@@ -419,35 +421,43 @@ describe('orderedReducer', () => {
         it('adds subcollection to existing doc within state', () => {
           const orderedData = { id: 'subDoc', someOther: 'thing' };
           const subcollection = { collection: 'testing2' };
+          const collection = 'testing';
+          const doc = 'doc';
           action = {
             meta: {
-              collection: 'testing',
-              doc: 'doc',
+              collection,
+              doc,
               subcollections: [subcollection],
             },
             merge: {}, // reset merge settings
             type: actionTypes.LISTENER_RESPONSE,
             payload: { ordered: [orderedData] },
           };
-          state = { testing: [{ id: 'doc', another: 'thing' }] };
-          const result = orderedReducer(state, action);
-          // Adds subcollection to document
-          expect(
-            result[`testing/doc/${subcollection.collection}`],
-          ).to.have.property('0.id', orderedData.id);
+          const originalState = {
+            [collection]: [{ id: 'doc', another: 'thing' }],
+          };
+          const result = orderedReducer(originalState, action);
+          // Adds subcollection
+          expect(result[`${collection}/${doc}`]).to.have.nested.property(
+            '0.id',
+            orderedData.id,
+          );
           // Preserves original value
-          expect(
-            result[`testing/doc/${subcollection.collection}`],
-          ).to.have.property('another', 'thing');
+          expect(result[collection]).to.have.nested.property(
+            '0.id',
+            originalState[collection][0].id,
+          );
         });
 
         it('perserves existing collections on doc updates', () => {
           const orderedData = { id: 'doc', someOther: 'thing' };
           const original = [{ id: 'subDoc' }];
+          const collection = 'testing';
+          const doc = 'doc';
           action = {
             meta: {
-              collection: 'testing',
-              doc: 'doc',
+              collection,
+              doc,
             },
             merge: {}, // reset merge settings
             type: actionTypes.LISTENER_RESPONSE,
@@ -457,7 +467,7 @@ describe('orderedReducer', () => {
           const result = orderedReducer(state, action);
           // Updates parameter in document
           expect(result).to.have.nested.property(
-            `testing.0.someOther`,
+            `${collection}.0.someOther`,
             orderedData.someOther,
           );
           // Preserves documents in original subcollection
@@ -490,12 +500,15 @@ describe('orderedReducer', () => {
       });
 
       it('removes data from subcollection if payload is empty', () => {
-        const original = [{ id: 'subDoc' }];
+        const original = { data: 'asdf' };
+        const collection = 'testing';
+        const doc = 'doc';
+        const subcollection = { collection: 'original' };
         action = {
           meta: {
-            collection: 'testing',
-            doc: 'doc',
-            subcollections: [{ collection: 'original' }],
+            collection,
+            doc,
+            subcollections: [subcollection],
           },
           merge: {}, // reset merge settings
           type: actionTypes.LISTENER_RESPONSE,
@@ -503,8 +516,15 @@ describe('orderedReducer', () => {
         };
         state = { testing: [{ id: 'doc', original }] };
         const result = orderedReducer(state, action);
+        // Does not remove document
+        expect(result).to.have.nested.property(
+          `${collection}.0.original.data`,
+          original.data,
+        );
         // Removes subcollection
-        expect(result).to.not.have.nested.property('testing.0.original');
+        expect(result[`${collection}/${doc}`]).to.not.have.nested.property(
+          `${collection}.0.original`,
+        );
       });
 
       it('stores data under storeAs', () => {

--- a/test/unit/utils/reducers.spec.js
+++ b/test/unit/utils/reducers.spec.js
@@ -1,14 +1,9 @@
 import {
   getDotStrPath,
-  pathFromMeta,
   getSlashStrPath,
   preserveValuesFromState,
-  updateItemInArray,
   createReducer,
 } from 'utils/reducers';
-
-let subcollections;
-let config;
 
 describe('reducer utils', () => {
   describe('getSlashStrPath', () => {
@@ -38,95 +33,6 @@ describe('reducer utils', () => {
     });
     it('returns empty string for undefined input', () => {
       expect(getDotStrPath()).to.equal('');
-    });
-  });
-
-  describe('pathFromMeta', () => {
-    it('is exported', () => {
-      expect(pathFromMeta).to.be.a('function');
-    });
-
-    it('throws for no meta data passed (first argument)', () => {
-      expect(() => pathFromMeta()).to.throw(
-        'Action meta is required to build path for reducers.',
-      );
-    });
-
-    it('returns undefined if provided nothing', () => {
-      expect(() => pathFromMeta({})).to.throw(
-        'Collection is required to construct reducer path.',
-      );
-    });
-
-    it('returns collection if provided', () => {
-      expect(pathFromMeta({ collection: 'test' })).to.equal('test');
-    });
-
-    it('returns collection doc combined into dot path if both provided', () => {
-      expect(pathFromMeta({ collection: 'first', doc: 'second' })).to.equal(
-        'first.second',
-      );
-    });
-
-    it('uses storeAs as path if provided', () => {
-      pathFromMeta({ storeAs: 'testing' });
-    });
-
-    it('uses path as path if provided', () => {
-      expect(pathFromMeta({ path: 'testing' })).to.have.property(0, 'testing');
-    });
-
-    describe('updateItemInArray', () => {
-      it('is exported', () => {
-        expect(updateItemInArray).to.be.a('function');
-      });
-
-      it('returns an array when no arguments are passed', () => {
-        expect(updateItemInArray([], '123', () => ({}))).to.be.an('array');
-      });
-
-      it('preserves items which do not have matching ids', () => {
-        const testId = '123ABC';
-        const result = updateItemInArray(
-          [{ id: 'other' }, { id: testId }],
-          testId,
-          () => 'test',
-        );
-        expect(result[0]).to.have.property('id', 'other');
-      });
-
-      it('updates item with matching id', () => {
-        const testId = '123ABC';
-        const result = updateItemInArray(
-          [{ id: testId }],
-          testId,
-          () => 'test',
-        );
-        expect(result[0]).to.equal('test');
-      });
-    });
-
-    describe('supports a subcollection', () => {
-      it('with collection', () => {
-        subcollections = [{ collection: 'third' }];
-        config = { collection: 'first', doc: 'second', subcollections };
-        expect(pathFromMeta(config)).to.equal('first.second.third');
-      });
-
-      it('with doc', () => {
-        subcollections = [{ collection: 'third', doc: 'forth' }];
-        config = { collection: 'first', doc: 'second', subcollections };
-        expect(pathFromMeta(config)).to.equal('first.second.third.forth');
-      });
-    });
-
-    it('supports multiple subcollections', () => {
-      subcollections = [
-        { collection: 'third', doc: 'forth' },
-        { collection: 'fifth' },
-      ];
-      config = { collection: 'first', doc: 'second', subcollections };
-      expect(pathFromMeta(config)).to.equal('first.second.third.forth.fifth');
     });
   });
 


### PR DESCRIPTION
## Description
### Features
* [X] feat(reducers): `ordered` and `data` reducer using new v1 state pattern outlined in [the v1.0.0 roadmap](https://github.com/prescottprue/redux-firestore/wiki/v1.0.0-Roadmap) (full query path in ordered, sub-collections separate from doc in data)
* [X] feat(core): `firestoreDataSelector ` and`firestoreOrderedSelector` utilities for selecting values from state

### Bugfixes
*Each bugfix will be checked off when it has been verified*
* [X] bug(reducers): LISTENER_RESPONSE action not correctly updating state for sub-collections - #103
* [X] bug(reducers): ordered state not updated with added item in array - #116
* [X] bug(reducers): updates to arrays inside documents don't work as expected - #140

## Check List
If not relevant to pull request, check off as complete

- [x] All original tests passing
- [X] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

## Relevant Issues
* #103
* #116 
* #140 
