### PR TITLE
fix for storeAs and documents that contain a dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ es
 *.log
 coverage
 .idea
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
     "watch": "npm run build:es -- --watch",
+    "watch:lib": "npm run build:lib -- --watch",
     "watch:commonjs": "npm run build:commonjs -- --watch",
     "test": "mocha -R spec ./test/unit/**",
     "test:cov": "istanbul cover  $(npm bin)/_mocha ./test/unit/**",

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -46,18 +46,18 @@ export default function dataReducer(state = {}, action) {
       // Data to set to state is doc if doc name exists within meta
       const data = docName ? get(payload.data, docName) : payload.data;
       // Get previous data at path to check for existence
-      const previousData = get(state, meta.storeAs || pathFromMeta(meta));
+      const previousData = get(state, meta.storeAs ? [meta.storeAs] : pathFromMeta(meta));
       // Set data (without merging) if no previous data exists or if there are subcollections
       if (!previousData || meta.subcollections) {
         // Set data to state immutabily (lodash/fp's setWith creates copy)
-        return setWith(Object, meta.storeAs || pathFromMeta(meta), data, state);
+        return setWith(Object, meta.storeAs ? [meta.storeAs] : pathFromMeta(meta), data, state);
       }
       // Otherwise merge with existing data
       const mergedData = assign(previousData, data);
       // Set data to state (with merge) immutabily (lodash/fp's setWith creates copy)
       return setWith(
         Object,
-        meta.storeAs || pathFromMeta(meta),
+        meta.storeAs ? [meta.storeAs] : pathFromMeta(meta),
         mergedData,
         state,
       );

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -46,11 +46,19 @@ export default function dataReducer(state = {}, action) {
       // Data to set to state is doc if doc name exists within meta
       const data = docName ? get(payload.data, docName) : payload.data;
       // Get previous data at path to check for existence
-      const previousData = get(state, meta.storeAs ? [meta.storeAs] : pathFromMeta(meta));
+      const previousData = get(
+        state,
+        meta.storeAs ? [meta.storeAs] : pathFromMeta(meta),
+      );
       // Set data (without merging) if no previous data exists or if there are subcollections
       if (!previousData || meta.subcollections) {
         // Set data to state immutabily (lodash/fp's setWith creates copy)
-        return setWith(Object, meta.storeAs ? [meta.storeAs] : pathFromMeta(meta), data, state);
+        return setWith(
+          Object,
+          meta.storeAs ? [meta.storeAs] : pathFromMeta(meta),
+          data,
+          state,
+        );
       }
       // Otherwise merge with existing data
       const mergedData = assign(previousData, data);

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -79,7 +79,7 @@ export function pathFromMeta(meta) {
   const { collection, doc, subcollections, storeAs } = meta;
   if (storeAs) {
     // Use array here - if we don't we end up in trouble with docs that contain a dot
-    return doc ? [storeAs, doc] : storeAs;
+    return doc ? [storeAs, doc] : [storeAs];
   }
   if (meta.path) {
     return meta.path.split('/');

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -78,7 +78,8 @@ export function pathFromMeta(meta) {
   }
   const { collection, doc, subcollections, storeAs } = meta;
   if (storeAs) {
-    return doc ? `${storeAs}.${doc}` : storeAs;
+    // Use array here - if we don't we end up in trouble with docs that contain a dot
+    return doc ? [storeAs, doc] : storeAs;
   }
   if (meta.path) {
     return meta.path.split('/');

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -5,7 +5,7 @@ import {
   pick,
   replace,
   trimStart,
-  flatten
+  flatten,
 } from 'lodash';
 
 /**

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -5,6 +5,7 @@ import {
   pick,
   replace,
   trimStart,
+  flatten
 } from 'lodash';
 
 /**
@@ -100,7 +101,8 @@ export function pathFromMeta(meta) {
   }
 
   const mappedCollections = subcollections.map(pathFromMeta);
-  return [...basePath, ...mappedCollections.flat()];
+
+  return [...basePath, ...flatten(mappedCollections)];
 }
 
 /**

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -69,7 +69,7 @@ export function combineReducers(reducers) {
  * @param  {String} meta.storeAs - Another key within redux store that the
  * action associates with (used for storing data under a path different
  * from its collection/document)
- * @return {String} String path to be used within reducer
+ * @return {Array} Array with path segments
  * @private
  */
 export function pathFromMeta(meta) {
@@ -84,18 +84,23 @@ export function pathFromMeta(meta) {
   if (meta.path) {
     return meta.path.split('/');
   }
+
   if (!collection) {
     throw new Error('Collection is required to construct reducer path.');
   }
-  let basePath = collection;
+
+  let basePath = [collection];
+
   if (doc) {
-    basePath += `.${doc}`;
+    basePath = [...basePath, doc];
   }
+
   if (!subcollections) {
     return basePath;
   }
+
   const mappedCollections = subcollections.map(pathFromMeta);
-  return basePath.concat(`.${mappedCollections.join('.')}`);
+  return [...basePath, ...mappedCollections.flat()];
 }
 
 /**


### PR DESCRIPTION
### Description
Setwith in our datareducer can work with both a string and an array. If we do provide an array it will treat every element as separate object property. It won't try to transform

com.something.else into
com : { something: {else: ...}}}
but it will treat it as com.something.else = value

This seems to solve our issues with wrong paths for documents that contain a dot.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/redux-firestore/issues/139
