### PR TITLE
fix(reducers): non-debug mode for react-native on android

### DIFF
--- a/src/reducers/crossSliceReducer.js
+++ b/src/reducers/crossSliceReducer.js
@@ -1,7 +1,7 @@
 /* eslint-disable guard-for-in, no-restricted-syntax, no-param-reassign */
 
 import produce from 'immer';
-import { values, groupBy, merge, set, get } from 'lodash';
+import { values, groupBy, merge, set, get, keys } from 'lodash';
 import { actionTypes } from '../constants';
 
 export default function crossSliceReducer(state = {}, action) {
@@ -18,13 +18,14 @@ export default function crossSliceReducer(state = {}, action) {
           c => c.storeAs || c.collection,
         );
 
-        for (const storeAs in groups) {
+        keys(groups).forEach(storeAs => {
           const updated = {};
-          for (const item of groups[storeAs]) {
-            merge(updated, get(item, 'data', {}));
-          }
+          groups[storeAs].forEach(item =>
+            merge(updated, get(item, 'data', {})),
+          );
+
           set(draft, ['composite', storeAs], updated);
-        }
+        });
 
         return draft;
       default:


### PR DESCRIPTION
For some reason the code in this pull request
https://github.com/prescottprue/redux-firestore/pull/130

breaks react-native in non-debug mode.

With those changes here it is working fine
https://github.com/prescottprue/redux-firestore/pull/130/files/f7af74872ffcbb2da80395050b0afb08c0e57334

### Description
@prescottprue - as discussed here https://github.com/prescottprue/redux-firestore/pull/130 with your proposed changes non-debug mode in react native on android works fine. 

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/redux-firestore/pull/130
