### PR TITLE
Made sure getPopulateChild includes object id

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -418,7 +418,7 @@ export function dataByIdSnapshot(snap) {
 export function getPopulateChild(firebase, populate, id) {
   return firestoreRef(firebase, { collection: populate.root, doc: id })
     .get()
-    .then(snap => snap.data());
+    .then(snap => Object.assign({ id: id }, snap.data()));
 }
 
 /**

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -418,7 +418,7 @@ export function dataByIdSnapshot(snap) {
 export function getPopulateChild(firebase, populate, id) {
   return firestoreRef(firebase, { collection: populate.root, doc: id })
     .get()
-    .then(snap => Object.assign({ id: id }, snap.data()));
+    .then(snap => Object.assign({ id }, snap.data()));
 }
 
 /**


### PR DESCRIPTION
Related to issue #169

### Description
Made sure we don't lose the document `id` when populating.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
#169
