### PR TITLE
fix(query): getQueryName correctly handles storeAs to allow for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections*
+*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
 
 ##### startAfter
 
@@ -391,7 +391,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections*
+*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
 
 ##### endAt
 
@@ -408,7 +408,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections*
+*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
 
 ##### endBefore
 
@@ -425,7 +425,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections*
+*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
 
 ##### storeAs
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ export function firestoreReducer(state: object, action: object): any;
  */
 export function createFirestoreInstance(
   firebaseInstance: object,
-  configs: Config,
+  config: Config,
   dispatch: () => object
 ): object;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ export interface Config {
  */
 export function reduxFirestore(
   firebaseInstance: object,
-  otherConfig?: Config
+  otherConfig?: Partial<Config>
 ): any;
 
 /**
@@ -123,7 +123,7 @@ export function reduxFirestore(
  */
 export function getFirestore(
   firebaseInstance: object,
-  otherConfig?: Config
+  otherConfig?: Partial<Config>
 ): any;
 
 /**
@@ -136,7 +136,7 @@ export function firestoreReducer(state: object, action: object): any;
  */
 export function createFirestoreInstance(
   firebaseInstance: object,
-  configs: Config,
+  configs: Partial<Config>,
   dispatch: () => object
 ): object;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,41 +72,41 @@ export const constants: {
   defaultConfig: Config;
 };
 
-interface Config {
-  enableLogging?: boolean;
+export interface Config {
+  enableLogging: boolean;
 
-  helpersNamespace?: string | null;
+  helpersNamespace: string | null;
 
   // https://github.com/prescottprue/redux-firestore#loglistenererror
-  logListenerError?: boolean;
+  logListenerError: boolean;
 
   // https://github.com/prescottprue/redux-firestore#enhancernamespace
-  enhancerNamespace?: string;
+  enhancerNamespace: string;
 
   // https://github.com/prescottprue/redux-firestore#allowmultiplelisteners
-  allowMultipleListeners?:
+  allowMultipleListeners:
     | ((listenerToAttach: any, currentListeners: any) => boolean)
     | boolean;
 
   // https://github.com/prescottprue/redux-firestore#preserveondelete
-  preserveOnDelete?: null | object;
+  preserveOnDelete: null | object;
 
   // https://github.com/prescottprue/redux-firestore#preserveonlistenererror
-  preserveOnListenerError?: null | object;
+  preserveOnListenerError: null | object;
 
   // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
-  onAttemptCollectionDelete?:
+  onAttemptCollectionDelete:
     | null
     | ((queryOption, dispatch, firebase) => void);
 
   // https://github.com/prescottprue/redux-firestore#mergeordered
-  mergeOrdered?: boolean;
+  mergeOrdered: boolean;
 
   // https://github.com/prescottprue/redux-firestore#mergeordereddocupdate
-  mergeOrderedDocUpdate?: boolean;
+  mergeOrderedDocUpdate: boolean;
 
   // https://github.com/prescottprue/redux-firestore#mergeorderedcollectionupdates
-  mergeOrderedCollectionUpdates?: boolean;
+  mergeOrderedCollectionUpdates: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import * as Firebase from 'firebase';
+
 /**
  * Action types used within actions dispatched internally. These action types
  * can be manually dispatched to update state.
@@ -95,9 +97,7 @@ export interface Config {
   preserveOnListenerError: null | object;
 
   // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
-  onAttemptCollectionDelete:
-    | null
-    | ((queryOption, dispatch, firebase) => void);
+  onAttemptCollectionDelete: null | ((queryOption, dispatch, firebase) => void);
 
   // https://github.com/prescottprue/redux-firestore#mergeordered
   mergeOrdered: boolean;
@@ -114,16 +114,16 @@ export interface Config {
  * context through react-redux's <Provider>).
  */
 export function reduxFirestore(
-  firebaseInstance: object,
-  otherConfig?: Partial<Config>
+  firebaseInstance: typeof Firebase,
+  otherConfig?: Partial<Config>,
 ): any;
 
 /**
  * Get extended firestore instance (attached to store.firestore)
  */
 export function getFirestore(
-  firebaseInstance: object,
-  otherConfig?: Partial<Config>
+  firebaseInstance: typeof Firebase,
+  otherConfig?: Partial<Config>,
 ): any;
 
 /**
@@ -135,9 +135,9 @@ export function firestoreReducer(state: object, action: object): any;
  * Create a firestore instance that has helpers attached for dispatching actions
  */
 export function createFirestoreInstance(
-  firebaseInstance: object,
+  firebaseInstance: typeof Firebase,
   configs: Partial<Config>,
-  dispatch: () => object
+  dispatch: () => object,
 ): object;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,28 +69,62 @@ export const constants: {
     ON_SNAPSHOT_FAILURE: string;
   };
   actionsPrefix: string;
-  defaultConfig: {
-    enableLogging: boolean;
-    enhancerNamespace: string;
-    helpersNamespace: string;
-    preserveOnListenerError: object;
-    preserveOnDelete: object;
-    logListenerError: boolean;
-    allowMultipleListeners: any;
-    onAttemptCollectionDelete: any;
-  };
+  defaultConfig: Config;
 };
+
+interface Config {
+  enableLogging?: boolean;
+
+  helpersNamespace?: string | null;
+
+  // https://github.com/prescottprue/redux-firestore#loglistenererror
+  logListenerError?: boolean;
+
+  // https://github.com/prescottprue/redux-firestore#enhancernamespace
+  enhancerNamespace?: string;
+
+  // https://github.com/prescottprue/redux-firestore#allowmultiplelisteners
+  allowMultipleListeners?:
+    | ((listenerToAttach: any, currentListeners: any) => boolean)
+    | boolean;
+
+  // https://github.com/prescottprue/redux-firestore#preserveondelete
+  preserveOnDelete?: null | object;
+
+  // https://github.com/prescottprue/redux-firestore#preserveonlistenererror
+  preserveOnListenerError?: null | object;
+
+  // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
+  onAttemptCollectionDelete?:
+    | null
+    | ((queryOption, dispatch, firebase) => void);
+
+  // https://github.com/prescottprue/redux-firestore#mergeordered
+  mergeOrdered?: boolean;
+
+  // https://github.com/prescottprue/redux-firestore#mergeordereddocupdate
+  mergeOrderedDocUpdate?: boolean;
+
+  // https://github.com/prescottprue/redux-firestore#mergeorderedcollectionupdates
+  mergeOrderedCollectionUpdates?: boolean;
+}
 
 /**
  * A redux store enhancer that adds store.firebase (passed to React component
  * context through react-redux's <Provider>).
  */
-export function reduxFirestore(firebaseInstance: object, otherConfig?: object): any;
+export function reduxFirestore(
+  firebaseInstance: object,
+  otherConfig?: Config
+): any;
 
 /**
  * Get extended firestore instance (attached to store.firestore)
  */
-export function getFirestore(firebaseInstance: object, otherConfig?: object): any;
+export function getFirestore(
+  firebaseInstance: object,
+  otherConfig?: Config
+): any;
 
 /**
  * A redux store reducer for Firestore state
@@ -100,20 +134,22 @@ export function firestoreReducer(state: object, action: object): any;
 /**
  * Create a firestore instance that has helpers attached for dispatching actions
  */
-export function createFirestoreInstance(firebaseInstance: object, configs: object, dispatch: () => object): object;
+export function createFirestoreInstance(
+  firebaseInstance: object,
+  configs: Config,
+  dispatch: () => object
+): object;
 
 /**
  * A redux store reducer for Firestore state
  */
 export namespace firestoreReducer {
-  const prototype: {
-  };
+  const prototype: {};
 }
 
 /**
  * A redux store reducer for Firestore state
  */
 export namespace reduxFirestore {
-  const prototype: {
-  };
+  const prototype: {};
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ export function firestoreReducer(state: object, action: object): any;
  */
 export function createFirestoreInstance(
   firebaseInstance: object,
-  config: Config,
+  configs: Config,
   dispatch: () => object
 ): object;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,6 +1124,231 @@
         }
       }
     },
+    "@firebase/app": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.3.9.tgz",
+      "integrity": "sha512-mjgBSQsjln5vAV4zDIn3gjsRlcvn6KxMVNGdhdJmrHRPfjBYUQJycn2X3xwF0krwB41WS8SQCsHHQssXY+kfVQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.3.4",
+        "@firebase/util": "0.2.7",
+        "dom-storage": "2.1.0",
+        "tslib": "1.9.0",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/app-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.3.4.tgz",
+      "integrity": "sha512-XIc1wu7CJ0469STQPwyuokcBGFpRr7BVKKdajj/wAxzNntatDTXo1jdGfmjA8UYcuvW+QJmMkOE9KIOf5HgSzw==",
+      "dev": true
+    },
+    "@firebase/auth": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.9.3.tgz",
+      "integrity": "sha512-6NytqF693I+Y0iKvL+JNOOToBgA7fPRHCoGK4PCBzzGfpRB7Ou5QUdhNA/2HWNxQyA/GyqHhtUH3lQeV4nBJMg==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.5.2"
+      }
+    },
+    "@firebase/auth-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.5.2.tgz",
+      "integrity": "sha512-EU/b3eakCgmOFTti+DOQFgdtA62exlN12VaAZc7Yw8Ld7r7nP4fL9+S9JP1uBOTcpJEoTPE75Wc/+RBClxlf8g==",
+      "dev": true
+    },
+    "@firebase/database": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.3.12.tgz",
+      "integrity": "sha512-Gim1kYUXBOX7xYwrBY6sOgQerOkhYGYvwwPCFeuBTXVy6X8b98SCSk7oMrmrG0+tG6gosmq7CT59AOxZEx4/0Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/database-types": "0.3.5",
+        "@firebase/logger": "0.1.6",
+        "@firebase/util": "0.2.7",
+        "faye-websocket": "0.11.1",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/database-types": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.3.5.tgz",
+      "integrity": "sha512-MB98w9DsZtTN45sf651s5z4f2zdn5gPi2SMaZk32HLihPDgKv5pepzZ+grxioM7z5ZU1EvjjXRL7oM81OH3mZQ==",
+      "dev": true
+    },
+    "@firebase/firestore": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.0.4.tgz",
+      "integrity": "sha512-WgeCEeCNcqOHMJmvAoyo18wfuuJR1+O7zbi7Myt/oaIBWQSC5z4+vt6b/xJiqhMkjDJgMddP567kcsiV/nYvsw==",
+      "dev": true,
+      "requires": {
+        "@firebase/firestore-types": "1.0.2",
+        "@firebase/logger": "0.1.6",
+        "@firebase/webchannel-wrapper": "0.2.13",
+        "grpc": "1.18.0",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.0.2.tgz",
+      "integrity": "sha512-VJFxX3gC8hRm+UiKFk4rniQro3hRzeN9jFmmc2qq0qOO2KXrArc49tl7mj2c9pNPT+8la2xnmNXZ3g7ddJyd8Q==",
+      "dev": true
+    },
+    "@firebase/functions": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.3.7.tgz",
+      "integrity": "sha512-Z6GZSnM98pu7BpkKw4wzZEQ5z41A/N0PZKp4AmDc/Sc0kD0vveSJLV14ztykaxTU4b38w534LRJ0cZEIeLyicg==",
+      "dev": true,
+      "requires": {
+        "@firebase/functions-types": "0.2.3",
+        "@firebase/messaging-types": "0.2.5",
+        "isomorphic-fetch": "2.2.1",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.2.3.tgz",
+      "integrity": "sha512-/26AIgmwM9CQwWOXqK/A6AojTEYwEU/c6KbRk7ljny3k5aqRr+4fbYgDzCS2lriaExhLkXfYPx9MtjpDLO7YCQ==",
+      "dev": true
+    },
+    "@firebase/logger": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.6.tgz",
+      "integrity": "sha512-74COMdYK/CZBgCSzEJGtQYpi1wGg1QlCUTQ/BrqqEIGg7GcnEcUCyjtRLogRQPYj3P7qaJLzHTSErJ8ZUAGotQ==",
+      "dev": true
+    },
+    "@firebase/messaging": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.3.11.tgz",
+      "integrity": "sha512-2kcJ7YIcik0qTe/ot33QnGqyRFW+QKGfw/SHcX1Ta7p8fptEPO3T5dCrnPTPBjQJZ5hsIiYg493O1ebgm/BVWg==",
+      "dev": true,
+      "requires": {
+        "@firebase/messaging-types": "0.2.5",
+        "@firebase/util": "0.2.7",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.2.5.tgz",
+      "integrity": "sha512-t0wyC8KdT+4ahV7DdaDov8S2zrcNOkxHjg0nP1XwaP5RpBmCQKIQ+acLKp81aR7ihRRabY8krpJ0wYTHv1+cqA==",
+      "dev": true
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.6.tgz",
+      "integrity": "sha512-C75qCebkyKnR2q65zEMB/bUe8dR+lDk8CiWBM5QedRijVIZBsXRjCjausvk6sgl6QUTBDlRG89+ohT/dg/uRVw==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.5",
+        "promise-polyfill": "7.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/storage": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.2.8.tgz",
+      "integrity": "sha512-Tj4nCSAptuMo2gvowP7EZerIuTBXE25HAdUAapBhwsaoKLXEPTzaCh40pfOV8PlQ7DPntqQhGWlpDEmDYdiJ6Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/storage-types": "0.2.5",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.2.5.tgz",
+      "integrity": "sha512-6M7iIPhhyA2Vgn+Hfqtonns5mo+hSPeK3UgaYCTmnmQ+CNcjYuo5srBa/z6YvaLByfhiEhrrR5I8iCk4HyzQDQ==",
+      "dev": true
+    },
+    "@firebase/util": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.7.tgz",
+      "integrity": "sha512-I6rN6smH1XEXUIDySI2jr4pM8r2tBnE40mANYco2lbzs2D0nk9aiwKp5MTWRAmqRy4WDe7sx9sqs0cFefzsD6A==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.13.tgz",
+      "integrity": "sha512-wsw8PBkojAfdz3ROMmO6Kk8BbzVsDO4Mhrh2EHJMxSzzKjd7NyXMKpGh9YOA1BY5gfMGQn/M+IVNR0KMryc5Xg==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -1509,6 +1734,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "dev": true,
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -2144,6 +2379,15 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "dev": true,
+      "requires": {
+        "long": "~3"
+      }
+    },
     "cacache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
@@ -2249,8 +2493,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30000935",
@@ -2269,7 +2512,6 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -2432,7 +2674,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -2443,8 +2684,7 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2508,6 +2748,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
       "dev": true
     },
     "combined-stream": {
@@ -2966,6 +3212,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -3026,6 +3278,15 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -3649,6 +3910,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "faye-websocket": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -3758,6 +4028,22 @@
             "is-extglob": "^2.1.0"
           }
         }
+      }
+    },
+    "firebase": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-5.8.4.tgz",
+      "integrity": "sha512-weILpmo3b4PWKMGQMbGu93OytkHt7tGVXL62mtfpBoIR2iPDpZiOv/LIFK/H7Y9Vr4H5EFuIBWXlramxsQlKfA==",
+      "dev": true,
+      "requires": {
+        "@firebase/app": "0.3.9",
+        "@firebase/auth": "0.9.3",
+        "@firebase/database": "0.3.12",
+        "@firebase/firestore": "1.0.4",
+        "@firebase/functions": "0.3.7",
+        "@firebase/messaging": "0.3.11",
+        "@firebase/polyfill": "0.3.6",
+        "@firebase/storage": "0.2.8"
       }
     },
     "flat-cache": {
@@ -3890,7 +4176,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3911,12 +4198,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3931,17 +4220,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4058,7 +4350,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4070,6 +4363,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4084,6 +4378,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4091,12 +4386,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4115,6 +4412,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4195,7 +4493,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4207,6 +4506,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4292,7 +4592,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4328,6 +4629,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4347,6 +4649,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4390,12 +4693,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4529,6 +4834,490 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "grpc": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.18.0.tgz",
+      "integrity": "sha512-M0K67Zhv2ZzCjrTbQvjWgYFPB929L+qAVnbNgXepbfO5kJxUYc30dP8m8vb+o8QdahLHAeYfIqRoIzZRcCB98Q==",
+      "dev": true,
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.0.0",
+        "node-pre-gyp": "^0.12.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-packlist": {
+          "version": "1.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "handlebars": {
       "version": "4.0.11",
@@ -4750,6 +5539,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "http-parser-js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
       "dev": true
     },
     "http-signature": {
@@ -5323,6 +6118,16 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -5577,8 +6382,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lcid": {
       "version": "2.0.0",
@@ -5651,6 +6455,18 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -5667,6 +6483,12 @@
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
       "dev": true
     },
     "longest": {
@@ -5982,8 +6804,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -6060,6 +6881,16 @@
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-libs-browser": {
@@ -6322,6 +7153,12 @@
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
       }
+    },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4=",
+      "dev": true
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -6657,6 +7494,12 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
@@ -6665,6 +7508,18 @@
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
+      }
+    },
+    "protobufjs": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+      "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+      "dev": true,
+      "requires": {
+        "ascli": "~1",
+        "bytebuffer": "~5",
+        "glob": "^7.0.5",
+        "yargs": "^3.10.0"
       }
     },
     "prr": {
@@ -7194,7 +8049,6 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -8778,6 +9632,28 @@
         }
       }
     },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -8797,8 +9673,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -8879,6 +9754,12 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -8902,7 +9783,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true,
       "requires": {
         "camelcase": "^1.0.2",
         "cliui": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
+    "firebase": "^5.8.4",
     "husky": "^1.3.1",
     "istanbul": "1.1.0-alpha.1",
     "mocha": "^5.2.0",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -270,10 +270,7 @@ export function setListeners(firebase, dispatch, listeners) {
   // Only attach one listener (count of matching listener path calls is tracked)
   if (config.oneListenerPerPath) {
     return listeners.forEach(listener => {
-      const path =
-        getQueryName(listener) +
-        (listener.storeAs ? `-${listener.storeAs}` : '');
-
+      const path = getQueryName(listener);
       const oldListenerCount = pathListenerCounts[path] || 0;
       pathListenerCounts[path] = oldListenerCount + 1;
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -76,7 +76,7 @@ function handleSubcollections(ref, subcollectionList) {
         if (!isFunction(ref.collection)) {
           throw new Error(
             `Collection can only be run on a document. Check that query config for subcollection: "${
-              subcollection.collection
+            subcollection.collection
             }" contains a doc parameter.`,
           );
         }
@@ -148,11 +148,9 @@ export function firestoreRef(firebase, meta) {
  * @return {String} String representing where settings for use in query name
  */
 function arrayToStr(key, value) {
-  return isString(value) || isNumber(value)
-    ? `${key}=${value}`
-    : isString(value[0])
-    ? `${key}=${value.join(':')}`
-    : value.map(value => arrayToStr(key, value));
+  if (isString(value) || isNumber(value)) return `${key}=${value}`;
+  if (isString(value[0])) return;
+  return value.map(val => arrayToStr(key, val));
 }
 
 function pickQueryParams(obj) {
@@ -169,7 +167,7 @@ function pickQueryParams(obj) {
 
 function serialize(queryParams) {
   return Object.entries(queryParams)
-    .filter(([key, value]) => value !== undefined)
+    .filter(([, value]) => value !== undefined)
     .map(([key, value]) => arrayToStr(key, value))
     .join('&');
 }
@@ -568,8 +566,7 @@ export function promisesForPopulate(
 
         // Parameter of each list item is single ID
         if (isString(idOrList)) {
-          return promisesArray.push(
-            // eslint-disable-line
+          return promisesArray.push( // eslint-disable-line
             getPopulateChild(firebase, p, idOrList).then(v => {
               // write child to result object under root name if it is found
               if (v) {
@@ -583,8 +580,7 @@ export function promisesForPopulate(
         // Parameter of each list item is a list of ids
         if (isArray(idOrList) || isObject(idOrList)) {
           // Create single promise that includes a promise for each child
-          return promisesArray.push(
-            // eslint-disable-line
+          return promisesArray.push( // eslint-disable-line
             populateList(firebase, idOrList, p, results),
           );
         }

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -225,7 +225,6 @@ export function getQueryName(meta) {
  * @param  {Object} meta - Metadata object containing query settings
  * @param  {String} meta.collection - Collection name of query
  * @param  {String} meta.doc - Document id of query
- * @param  {String} meta.storeAs - User-defined Redux store name of query
  * @param  {Array} meta.subcollections - Subcollections of query
  * @return {String} String representing query settings
  */
@@ -233,7 +232,7 @@ export function getBaseQueryName(meta) {
   if (isString(meta)) {
     return meta;
   }
-  const { collection, subcollections, storeAs, ...remainingMeta } = meta;
+  const { collection, subcollections, ...remainingMeta } = meta;
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -76,7 +76,7 @@ function handleSubcollections(ref, subcollectionList) {
         if (!isFunction(ref.collection)) {
           throw new Error(
             `Collection can only be run on a document. Check that query config for subcollection: "${
-            subcollection.collection
+              subcollection.collection
             }" contains a doc parameter.`,
           );
         }
@@ -149,7 +149,7 @@ export function firestoreRef(firebase, meta) {
  */
 function arrayToStr(key, value) {
   if (isString(value) || isNumber(value)) return `${key}=${value}`;
-  if (isString(value[0])) return;
+  if (isString(value[0])) return `${key}=${value.join(':')}`;
   return value.map(val => arrayToStr(key, val));
 }
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -3,6 +3,8 @@ import {
   isArray,
   isFunction,
   isObject,
+  isNumber,
+  isEmpty,
   size,
   trim,
   forEach,
@@ -142,13 +144,34 @@ export function firestoreRef(firebase, meta) {
 
 /**
  * Convert where parameter into a string notation for use in query name
- * @param  {Array} where - Where config array
+ * @param  {Array} value - Where config array
  * @return {String} String representing where settings for use in query name
  */
-function whereToStr(where) {
-  return isString(where[0])
-    ? `where=${where.join(':')}`
-    : where.map(whereToStr);
+function arrayToStr(key, value) {
+  return isString(value) || isNumber(value)
+    ? `${key}=${value}`
+    : isString(value[0])
+    ? `${key}=${value.join(':')}`
+    : value.map(value => arrayToStr(key, value));
+}
+
+function pickQueryParams(obj) {
+  return [
+    'where',
+    'orderBy',
+    'limit',
+    'startAfter',
+    'startAt',
+    'endAt',
+    'endBefore',
+  ].reduce((acc, key) => (obj[key] ? { ...acc, [key]: obj[key] } : acc), {});
+}
+
+function serialize(queryParams) {
+  return Object.entries(queryParams)
+    .filter(([key, value]) => value !== undefined)
+    .map(([key, value]) => arrayToStr(key, value))
+    .join('&');
 }
 
 /**
@@ -157,6 +180,7 @@ function whereToStr(where) {
  * @param  {Object} meta - Metadata object containing query settings
  * @param  {String} meta.collection - Collection name of query
  * @param  {String} meta.doc - Document id of query
+ * @param  {String} meta.storeAs - User-defined Redux store name of query
  * @param  {Array} meta.subcollections - Subcollections of query
  * @return {String} String representing query settings
  */
@@ -164,10 +188,15 @@ export function getQueryName(meta) {
   if (isString(meta)) {
     return meta;
   }
-  const { collection, doc, subcollections, where, limit } = meta;
+  const { collection, doc, subcollections, storeAs, ...remainingMeta } = meta;
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }
+
+  if (storeAs) {
+    return storeAs;
+  }
+
   let basePath = collection;
   if (doc) {
     basePath = basePath.concat(`/${doc}`);
@@ -178,15 +207,14 @@ export function getQueryName(meta) {
     );
     basePath = `${basePath}/${mappedCollections.join('/')}`;
   }
-  if (where) {
-    if (!isArray(where)) {
+
+  const queryParams = pickQueryParams(remainingMeta);
+
+  if (!isEmpty(queryParams)) {
+    if (queryParams.where && !isArray(queryParams.where)) {
       throw new Error('where parameter must be an array.');
     }
-    basePath = basePath.concat(`?${whereToStr(where)}`);
-  }
-  if (typeof limit !== 'undefined') {
-    const limitStr = `limit=${limit}`;
-    basePath = basePath.concat(`${where ? '&' : '?'}${limitStr}`);
+    basePath = basePath.concat('?', serialize(queryParams));
   }
   return basePath;
 }
@@ -197,6 +225,7 @@ export function getQueryName(meta) {
  * @param  {Object} meta - Metadata object containing query settings
  * @param  {String} meta.collection - Collection name of query
  * @param  {String} meta.doc - Document id of query
+ * @param  {String} meta.storeAs - User-defined Redux store name of query
  * @param  {Array} meta.subcollections - Subcollections of query
  * @return {String} String representing query settings
  */
@@ -204,7 +233,7 @@ export function getBaseQueryName(meta) {
   if (isString(meta)) {
     return meta;
   }
-  const { collection, subcollections, where, limit } = meta;
+  const { collection, subcollections, storeAs, ...remainingMeta } = meta;
   if (!collection) {
     throw new Error('Collection is required to build query name');
   }
@@ -216,16 +245,16 @@ export function getBaseQueryName(meta) {
     );
     basePath = `${basePath}/${mappedCollections.join('/')}`;
   }
-  if (where) {
-    if (!isArray(where)) {
+
+  const queryParams = pickQueryParams(remainingMeta);
+
+  if (!isEmpty(queryParams)) {
+    if (queryParams.where && !isArray(queryParams.where)) {
       throw new Error('where parameter must be an array.');
     }
-    basePath = basePath.concat(`?${whereToStr(where)}`);
+    basePath = basePath.concat('?', serialize(queryParams));
   }
-  if (typeof limit !== 'undefined') {
-    const limitStr = `limit=${limit}`;
-    basePath = basePath.concat(`${where ? '&' : '?'}${limitStr}`);
-  }
+
   return basePath;
 }
 
@@ -540,7 +569,8 @@ export function promisesForPopulate(
 
         // Parameter of each list item is single ID
         if (isString(idOrList)) {
-          return promisesArray.push( // eslint-disable-line
+          return promisesArray.push(
+            // eslint-disable-line
             getPopulateChild(firebase, p, idOrList).then(v => {
               // write child to result object under root name if it is found
               if (v) {
@@ -554,7 +584,8 @@ export function promisesForPopulate(
         // Parameter of each list item is a list of ids
         if (isArray(idOrList) || isObject(idOrList)) {
           // Create single promise that includes a promise for each child
-          return promisesArray.push( // eslint-disable-line
+          return promisesArray.push(
+            // eslint-disable-line
             populateList(firebase, idOrList, p, results),
           );
         }

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -76,7 +76,7 @@ function handleSubcollections(ref, subcollectionList) {
         if (!isFunction(ref.collection)) {
           throw new Error(
             `Collection can only be run on a document. Check that query config for subcollection: "${
-              subcollection.collection
+            subcollection.collection
             }" contains a doc parameter.`,
           );
         }
@@ -166,9 +166,9 @@ function pickQueryParams(obj) {
 }
 
 function serialize(queryParams) {
-  return Object.entries(queryParams)
-    .filter(([, value]) => value !== undefined)
-    .map(([key, value]) => arrayToStr(key, value))
+  return Object.keys(queryParams)
+    .filter((key) => queryParams[key] !== undefined)
+    .map((key) => arrayToStr(key, queryParams[key]))
     .join('&');
 }
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -76,7 +76,7 @@ function handleSubcollections(ref, subcollectionList) {
         if (!isFunction(ref.collection)) {
           throw new Error(
             `Collection can only be run on a document. Check that query config for subcollection: "${
-            subcollection.collection
+              subcollection.collection
             }" contains a doc parameter.`,
           );
         }
@@ -167,8 +167,8 @@ function pickQueryParams(obj) {
 
 function serialize(queryParams) {
   return Object.keys(queryParams)
-    .filter((key) => queryParams[key] !== undefined)
-    .map((key) => arrayToStr(key, queryParams[key]))
+    .filter(key => queryParams[key] !== undefined)
+    .map(key => arrayToStr(key, queryParams[key]))
     .join('&');
 }
 


### PR DESCRIPTION
### Description
- updates the TypeScript definitions for the Config
- in ` src/utils/query.js`, changes `getQueryName()` to return `storeAs` if defined, or appends all query params to enable pagination
- in `src/utils/query.js`, changes `getBaseQueryName()` to append all query params to enable pagination
- adds a relevant test in `test/unit/reducers/reducer.spec.js`
- removes a hack in `src/actions/firestore.js` because solved by the two changes above

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
#144 #107