### PR TITLE
fix(config): fix merging default configs in createFirestoreInstance()

### DIFF
--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -17,7 +17,7 @@ export default function createFirestoreInstance(firebase, configs, dispatch) {
     // Setup empty listeners object (later used to track listeners)
     listeners: {},
     // Extend default config with provided config
-    config: { defaultConfig, ...configs },
+    config: { ...defaultConfig, ...configs },
   };
 
   // extend existing firebase internals (using redux-firestore along with redux-firebase)


### PR DESCRIPTION
### Description

This fix adds the missing spread operator to `defaultConfig` in `createFirestoreInstance`

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
#184