### PR TITLE
v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
+*Can only be used with collections. Types can be a string, number, or Date object, but not a Firestore Document Snapshot*
 
 ##### startAfter
 
@@ -391,7 +391,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
+*Can only be used with collections. Types can be a string, number, or Date object, but not a Firestore Document Snapshot*
 
 ##### endAt
 
@@ -408,7 +408,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
+*Can only be used with collections. Types can be a string, number, or Date object, but not a Firestore Document Snapshot*
 
 ##### endBefore
 
@@ -425,7 +425,7 @@ Limit the query to a certain number of results
 },
 ```
 
-*Can only be used with collections.  Types can be a string or number, but not a Firestore Document Snapshot*
+*Can only be used with collections. Types can be a string, number, or Date object, but not a Firestore Document Snapshot*
 
 ##### storeAs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch:lib": "npm run build:lib -- --watch",
     "watch:commonjs": "npm run build:commonjs -- --watch",
     "test": "mocha -R spec ./test/unit/**",
-    "test:cov": "nyc mocha -R spec ./test/unit/**",
+    "test:cov": "nyc mocha -R spec ./test/unit/** && nyc report --reporter=lcov",
     "codecov": "cat coverage/lcov.info | codecov",
     "lint": "eslint src test",
     "lint:fix": "npm run lint -- --fix",

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -150,6 +150,8 @@ export function firestoreRef(firebase, meta) {
 function arrayToStr(key, value) {
   if (isString(value) || isNumber(value)) return `${key}=${value}`;
   if (isString(value[0])) return `${key}=${value.join(':')}`;
+  if (value && value.toString) return `${key}=${value.toString()}`;
+
   return value.map(val => arrayToStr(key, val));
 }
 

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -112,6 +112,24 @@ describe('query utils', () => {
         result = getQueryName(meta);
       });
     });
+
+    describe('startAt paremeter', () => {
+      it('is appended if valid', () => {
+        meta = {
+          collection: 'test',
+          startAt: 'asdf',
+        };
+        result = getQueryName(meta);
+      });
+
+      it('appends passed date objects (#186)', () => {
+        meta = {
+          collection: 'test',
+          startAt: new Date(),
+        };
+        result = getQueryName(meta);
+      });
+    });
   });
 
   describe('attachListener', () => {


### PR DESCRIPTION
### Description
* fix(query): allow date object as `startAt` (`arrayToStr` calls toString if it exists) - #186 - @nemo
* fix(tests): add a test case for `startAt` being passed to `getQueryName` - #186
* fix(docs): update query params docs to note they can accept date objects - #186
* fix(tests): correctly generate coverage in `lcov` format now that `nyc` is being used

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
* #186 
