### PR TITLE
fixes data/ not being properly updated if a query result is updated w…

### DIFF
--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -60,7 +60,7 @@ export default function dataReducer(state = {}, action) {
         );
       }
       // Otherwise merge with existing data
-      const mergedData = assign(previousData, data);
+      const mergedData = payload.data !== null ? assign(previousData, data) : null;
       // Set data to state (with merge) immutabily (lodash/fp's setWith creates copy)
       return setWith(
         Object,


### PR DESCRIPTION

### Description

Previously, when doing queries like below, if userId was removed from the `invitees` array, data was not properly updated. With this PR, data is properly updated.

```
firestoreConnect(props=> [{
      collection: 'events',
      populates,
      where: [
        ['invitees', 'array-contains', props.currentUser.uid],
      ],
      storeAs: 'events_invited'
    }]
)
```
 
### Check List
If not relevant to pull request, check off as complete

- [ x ] All tests passing
- [ ? ] Docs updated with any changes or examples if applicable
- [ ? ] Added tests to ensure new feature(s) work properly


