### PR TITLE
fix(typings): set type hints for onAttemptCollectionDelete

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as Firebase from 'firebase';
+import { Dispatch } from 'redux';
 
 /**
  * Action types used within actions dispatched internally. These action types
@@ -97,7 +98,7 @@ export interface Config {
   preserveOnListenerError: null | object;
 
   // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
-  onAttemptCollectionDelete: null | ((queryOption, dispatch, firebase) => void);
+  onAttemptCollectionDelete: null | ((queryOption: string, dispatch: Dispatch, firebase: Object) => void);
 
   // https://github.com/prescottprue/redux-firestore#mergeordered
   mergeOrdered: boolean;


### PR DESCRIPTION
### Description

With `noImplicitAny` setting enabled, projects are not compiling when type hints are missing. This fixes it.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
#194 
