### PR TITLE
fix(query): fix document updates by using deep clone on doc change event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3951,7 +3951,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3972,12 +3973,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3992,17 +3995,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4119,7 +4125,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4131,6 +4138,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4145,6 +4153,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4152,12 +4161,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4176,6 +4187,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4256,7 +4268,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4268,6 +4281,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4353,7 +4367,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4389,6 +4404,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4408,6 +4424,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4451,12 +4468,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -13,7 +13,7 @@ import {
   get,
   set,
   some,
-  cloneDeep
+  cloneDeep,
 } from 'lodash';
 import { actionTypes } from '../constants';
 
@@ -585,7 +585,8 @@ export function promisesForPopulate(
 
         // Parameter of each list item is single ID
         if (isString(idOrList)) {
-          return promisesArray.push( // eslint-disable-line
+          return promisesArray.push(
+            // eslint-disable-line
             getPopulateChild(firebase, p, idOrList).then(v => {
               // write child to result object under root name if it is found
               if (v) {
@@ -599,7 +600,8 @@ export function promisesForPopulate(
         // Parameter of each list item is a list of ids
         if (isArray(idOrList) || isObject(idOrList)) {
           // Create single promise that includes a promise for each child
-          return promisesArray.push( // eslint-disable-line
+          return promisesArray.push(
+            // eslint-disable-line
             populateList(firebase, idOrList, p, results),
           );
         }

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -578,6 +578,7 @@ export function promisesForPopulate(
         // get value of parameter to be populated (key or list of keys)
         const idOrList = get(d, p.child);
 
+        /* eslint-disable consistent-return */
         // Parameter/child of list item does not exist
         if (!idOrList) {
           return;

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -13,6 +13,7 @@ import {
   get,
   set,
   some,
+  cloneDeep
 } from 'lodash';
 import { actionTypes } from '../constants';
 
@@ -624,7 +625,7 @@ const changeTypeToEventType = {
  * @return {Object}                   [description]
  */
 function docChangeEvent(change, originalMeta = {}) {
-  const meta = { ...originalMeta, path: change.doc.ref.path };
+  const meta = { ...cloneDeep(originalMeta), path: change.doc.ref.path };
   if (originalMeta.subcollections && !originalMeta.storeAs) {
     meta.subcollections[0] = { ...meta.subcollections[0], doc: change.doc.id };
   } else {

--- a/test/unit/actions/firestore.spec.js
+++ b/test/unit/actions/firestore.spec.js
@@ -488,7 +488,7 @@ describe('firestoreActions', () => {
             );
             const expectedAction = {
               meta: { ...listenerConfig },
-              payload: { name: `test/1/test2/${docChanges[0].doc.id}` },
+              payload: { name: `test/1/test2` },
               type: actionTypes.SET_LISTENER,
             };
             await instance.test.setListener(listenerConfig);


### PR DESCRIPTION
### Description
Our team ran into an issue. We were listening to a collection with 3 documents, then we remove the 3 documents in a batch, but redux-firestore only removes one. 

It turned out that it is because redux-firestore adds a doc property to the meta object. The meta object should actually be a copy of the original meta, but since we don't do a deep clone there we end up modifying the original object.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
