### PR TITLE
fix(query/reducer): prevent updates to ordered when non-existent doc is queried

### DIFF
--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -181,6 +181,10 @@ function writeCollection(collectionState, action) {
   }
 
   if (meta.doc && collectionStateSize) {
+    // don't update ordered if the doc doesn't exist
+    if (!size(action.payload.ordered)) {
+      return collectionState;
+    }
     // Update item in array
     return updateItemInArray(collectionState, meta.doc, item =>
       mergeObjects(item, action.payload.ordered[0]),

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -436,8 +436,8 @@ export function orderedFromSnap(snap) {
  */
 export function dataByIdSnapshot(snap) {
   const data = {};
-  if (snap.data && snap.exists) {
-    data[snap.id] = snap.data();
+  if (snap.data) {
+    data[snap.id] = snap.exists ? snap.data() : null;
   } else if (snap.forEach) {
     snap.forEach(doc => {
       data[doc.id] = doc.data() || doc;

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -376,6 +376,36 @@ describe('orderedReducer', () => {
           );
         });
 
+        it('sets ordered to empty when doc does not exist', () => {
+          action = {
+            meta: { collection: 'testing', doc: 'doc' },
+            merge: {},
+            type: actionTypes.LISTENER_RESPONSE,
+            payload: { ordered: [] },
+          };
+          state = {};
+          const result = orderedReducer(state, action);
+
+          expect(result).to.have.property('testing');
+          // Value is an empty array
+          expect(result.testing).to.be.an('array');
+          expect(result.testing).to.be.empty;
+        });
+
+        it('does not modify existing state when doc does not exist', () => {
+          action = {
+            meta: { collection: 'testing', doc: 'doc' },
+            merge: {},
+            type: actionTypes.LISTENER_RESPONSE,
+            payload: { ordered: [] },
+          };
+          state = { testing: [{ id: 'testing2' }] };
+          const result = orderedReducer(state, action);
+          expect(result).to.have.property('testing');
+          // State not modified
+          expect(result.testing).to.equal(state.testing);
+        });
+
         it('updates doc already within state', () => {
           const id = 'doc';
           const someField = 'a thing';

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -817,10 +817,20 @@ describe('query utils', () => {
       expect(result).to.have.property(id, fakeData);
     });
 
-    it('returns null if no data returned', () => {
-      const id = 'someId';
-      result = dataByIdSnapshot({ id, data: () => ({}) });
+    it('returns null if no data returned for collection', () => {
+      const forEach = () => ({});
+      const empty = true;
+      result = dataByIdSnapshot({ forEach, empty });
       expect(result).to.be.null;
+    });
+
+    it('returns object with null id if no data returned for a doc', () => {
+      const id = 'someId';
+      const data = () => ({});
+      const exists = false;
+      result = dataByIdSnapshot({ id, exists, data });
+      expect(result).to.be.an('object');
+      expect(result).to.have.property(id, null);
     });
   });
 });


### PR DESCRIPTION
### Description
* Set data record to null when fetched doc doesn't exist
* don't update existing ordered state when doc doesn't exist
* Add relevant tests

### Check List
If not relevant to pull request, check off as complete

- [X] All tests passing
- [X] Docs updated with any changes or examples if applicable
- [X] Added tests to ensure new feature(s) work properly

### Relevant Issues
#179 
