### PR TITLE
fix(statusReducer): UNSET_LISTENER action type correctly updates status

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# These are supported funding model platforms
+
+# These are supported funding model platforms
+
+# github: [prescottprue]
+patreon: prescottprue
+open_collective: react-redux-firebase

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -2,7 +2,12 @@ import { actionTypes } from '../constants';
 import { getSlashStrPath, combineReducers } from '../utils/reducers';
 import { getQueryName } from '../utils/query';
 
-const { SET_LISTENER, LISTENER_ERROR, LISTENER_RESPONSE } = actionTypes;
+const {
+  SET_LISTENER,
+  UNSET_LISTENER,
+  LISTENER_ERROR,
+  LISTENER_RESPONSE,
+} = actionTypes;
 
 /**
  * Reducer for requesting state.Changed by `START`, `NO_VALUE`, and `SET` actions.
@@ -22,6 +27,7 @@ export function requestingReducer(state = {}, { type, meta }) {
       };
     case LISTENER_ERROR:
     case LISTENER_RESPONSE:
+    case UNSET_LISTENER:
       return {
         ...state,
         [getSlashStrPath(getQueryName(meta))]: false,
@@ -43,6 +49,7 @@ export function requestingReducer(state = {}, { type, meta }) {
 export function requestedReducer(state = {}, { type, meta }) {
   switch (type) {
     case SET_LISTENER:
+    case UNSET_LISTENER:
       return {
         ...state,
         [getQueryName(meta)]: false,

--- a/test/unit/reducers/statusReducer.spec.js
+++ b/test/unit/reducers/statusReducer.spec.js
@@ -87,16 +87,11 @@ describe('statusReducer', () => {
     });
 
     describe('UNSET_LISTENER', () => {
-      it('returns state if payload is not defined', () => {
+      it('sets requesting status to false when unsetting listener', () => {
         action = { meta: 'test', type: actionTypes.UNSET_LISTENER };
-        expect(statusReducer(state, action).requesting).to.be.empty;
-      });
-
-      it('does not set state', () => {
-        meta = { collection };
-        payload = {};
-        action = { meta, payload, type: actionTypes.UNSET_LISTENER };
-        expect(statusReducer(state, action).requesting).to.be.empty;
+        expect(statusReducer(state, action).requesting).to.deep.equal({
+          test: false,
+        });
       });
     });
   });


### PR DESCRIPTION
### Description
This PR makes sure that the `requested` and `requesting` status of `state.firestore.status` is updated when a listener is unset.

This is needed to prevent document paths being stuck forever on `requesting: true`, in case that a listener is unset before the document was fully loaded.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
#232 

