### PR TITLE
feat(core): add snapshot cache

### DIFF
--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -4,14 +4,15 @@ import { wrapInDispatch } from '../utils/actions';
 import { actionTypes } from '../constants';
 import {
   attachListener,
-  detachListener,
-  orderedFromSnap,
   dataByIdSnapshot,
+  detachListener,
+  dispatchListenerResponse,
+  firestoreRef,
+  getPopulateActions,
   getQueryConfig,
   getQueryName,
-  firestoreRef,
-  dispatchListenerResponse,
-  getPopulateActions,
+  orderedFromSnap,
+  snapshotCache,
 } from '../utils/query';
 
 const pathListenerCounts = {};
@@ -34,7 +35,11 @@ export function add(firebase, dispatch, queryOption, ...args) {
       actionTypes.ADD_REQUEST,
       {
         type: actionTypes.ADD_SUCCESS,
-        payload: snap => ({ id: snap.id, data: args[0] }),
+        payload: snap => {
+          const obj = { id: snap.id, data: args[0] };
+          snapshotCache.set(obj, snap);
+          return obj;
+        },
       },
       actionTypes.ADD_FAILURE,
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { firestoreActions } from './actions';
 import createFirestoreInstance from './createFirestoreInstance';
 import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
+import { getSnapshotByObject } from './utils/query';
 
 // converted with transform-inline-environment-variables
 export const version = process.env.npm_package_version;
@@ -16,6 +17,7 @@ export {
   createFirestoreInstance,
   firestoreActions as actions,
   getFirestore,
+  getSnapshotByObject,
   constants,
   actionTypes,
   middleware,
@@ -31,6 +33,7 @@ export default {
   createFirestoreInstance,
   actions: firestoreActions,
   getFirestore,
+  getSnapshotByObject,
   constants,
   actionTypes,
   middleware,

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -460,18 +460,18 @@ export function orderedFromSnap(snap) {
     const obj = isObject(snap.data())
       ? { id: snap.id, ...(snap.data() || snap.data) }
       : { id: snap.id, data: snap.data() };
-    snapshotCache.add(obj, snap);
+    snapshotCache.set(obj, snap);
     ordered.push(obj);
   } else if (snap.forEach) {
     snap.forEach(doc => {
       const obj = isObject(doc.data())
         ? { id: doc.id, ...(doc.data() || doc.data) }
         : { id: doc.id, data: doc.data() };
-      snapshotCache.add(obj, snap);
+      snapshotCache.set(obj, snap);
       ordered.push(obj);
     });
   }
-  snapshotCache.add(ordered, snap);
+  snapshotCache.set(ordered, snap);
   return ordered;
 }
 
@@ -486,18 +486,18 @@ export function dataByIdSnapshot(snap) {
   if (snap.data) {
     const snapData = snap.exists ? snap.data() : null;
     if (snapData) {
-      snapshotCache.add(snapData, snap);
+      snapshotCache.set(snapData, snap);
     }
     data[snap.id] = snapData;
   } else if (snap.forEach) {
     snap.forEach(doc => {
       const snapData = doc.data() || doc;
-      snapshotCache.add(snapData, snap);
+      snapshotCache.set(snapData, snap);
       data[doc.id] = snapData;
     });
   }
   if (!!data && Object.keys(data).length) {
-    snapshotCache.add(data, snap);
+    snapshotCache.set(data, snap);
     return data;
   }
   return null;

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -12,6 +12,23 @@ import {
 } from 'lodash';
 import { actionTypes } from '../constants';
 
+export const snapshotCache = new WeakMap();
+/**
+ * Get DocumentSnapshot and QuerySnapshot with object from either data or
+ * ordered firestore state. If provided with doc data, it will return
+ * DocumentSnapshot, providing with a collection from data or an array from
+ * ordered state will return QuerySnapshot, except ordered state that generated
+ * as DocumentRef will return DocumentSnapshot
+ * Note: the cache is local and, not persistance. Passing an object from initial
+ * state or from SSR state will yield undefined.
+ * @param {object|Array} obj - The object from data or ordered state
+ * @returns {firebase.firestore.DocumentSnapshot|firebase.firestore.QuerySnapshot}
+ * DocumentSnapshot or QuerySnapshot depend on type of object provided
+ */
+export function getSnapshotByObject(obj) {
+  return snapshotCache.get(obj);
+}
+
 /**
  * Add where claues to Cloud Firestore Reference handling invalid formats
  * and multiple where statements (array of arrays)
@@ -443,15 +460,18 @@ export function orderedFromSnap(snap) {
     const obj = isObject(snap.data())
       ? { id: snap.id, ...(snap.data() || snap.data) }
       : { id: snap.id, data: snap.data() };
+    snapshotCache.add(obj, snap);
     ordered.push(obj);
   } else if (snap.forEach) {
     snap.forEach(doc => {
       const obj = isObject(doc.data())
         ? { id: doc.id, ...(doc.data() || doc.data) }
         : { id: doc.id, data: doc.data() };
+      snapshotCache.add(obj, snap);
       ordered.push(obj);
     });
   }
+  snapshotCache.add(ordered, snap);
   return ordered;
 }
 
@@ -464,13 +484,23 @@ export function orderedFromSnap(snap) {
 export function dataByIdSnapshot(snap) {
   const data = {};
   if (snap.data) {
-    data[snap.id] = snap.exists ? snap.data() : null;
+    const snapData = snap.exists ? snap.data() : null;
+    if (snapData) {
+      snapshotCache.add(snapData, snap);
+    }
+    data[snap.id] = snapData;
   } else if (snap.forEach) {
     snap.forEach(doc => {
-      data[doc.id] = doc.data() || doc;
+      const snapData = doc.data() || doc;
+      snapshotCache.add(snapData, snap);
+      data[doc.id] = snapData;
     });
   }
-  return !!data && Object.keys(data).length ? data : null;
+  if (!!data && Object.keys(data).length) {
+    snapshotCache.add(data, snap);
+    return data;
+  }
+  return null;
 }
 
 /**

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -6,6 +6,7 @@ import {
   firestoreRef,
   orderedFromSnap,
   dataByIdSnapshot,
+  getSnapshotByObject,
 } from 'utils/query';
 import { actionTypes } from 'constants';
 
@@ -811,14 +812,14 @@ describe('query utils', () => {
   describe('dataByIdSnapshot', () => {
     it('sets data by id if valid', () => {
       const id = 'someId';
-      const fakeData = 'some';
+      const fakeData = { some: 'thing' };
       result = dataByIdSnapshot({ id, data: () => fakeData, exists: true });
       expect(result).to.have.property(id, fakeData);
     });
 
     it('supports collection data', () => {
       const id = 'someId';
-      const fakeData = 'some';
+      const fakeData = { some: 'thing' };
       result = dataByIdSnapshot({
         forEach: func => func({ data: () => fakeData, id }),
       });
@@ -839,6 +840,44 @@ describe('query utils', () => {
       result = dataByIdSnapshot({ id, exists, data });
       expect(result).to.be.an('object');
       expect(result).to.have.property(id, null);
+    });
+  });
+
+  describe('dataByIdSnapshot', () => {
+    it('retrieve snapshot with data from data state ', () => {
+      const id = 'someId';
+      const fakeData = { some: 'thing' };
+      const fakeSnap = { id, data: () => fakeData, exists: true };
+      result = dataByIdSnapshot(fakeSnap);
+      expect(getSnapshotByObject(result)).to.equal(fakeSnap);
+    });
+
+    it('retrieve snapshot with data from data collection state ', () => {
+      const id = 'someId';
+      const fakeData = { some: 'thing' };
+      const fakeDocSnap = { id, data: () => fakeData, exists: true };
+      const docArray = [fakeDocSnap];
+      const fakeSnap = { forEach: docArray.forEach.bind(docArray) };
+      result = dataByIdSnapshot(fakeSnap);
+      expect(getSnapshotByObject(result)).to.equal(fakeSnap);
+    });
+
+    it('retrieve snapshot with data from ordered state', () => {
+      const id = 'someId';
+      const fakeData = { some: 'thing' };
+      const fakeSnap = { id, data: () => fakeData, exists: true };
+      result = orderedFromSnap(fakeSnap);
+      expect(getSnapshotByObject(result)).to.equal(fakeSnap);
+    });
+
+    it('retrieve snapshot with data from ordered collection state ', () => {
+      const id = 'someId';
+      const fakeData = { some: 'thing' };
+      const fakeDocSnap = { id, data: () => fakeData, exists: true };
+      const docArray = [fakeDocSnap];
+      const fakeSnap = { forEach: docArray.forEach.bind(docArray) };
+      result = orderedFromSnap(fakeSnap);
+      expect(getSnapshotByObject(result)).to.equal(fakeSnap);
     });
   });
 });


### PR DESCRIPTION
### Description

Add snapshot cache

```
 Get DocumentSnapshot and QuerySnapshot with object from either data or
 ordered firestore state. If provided with doc data, it will return
 DocumentSnapshot, providing with a collection from data or an array from
 ordered state will return QuerySnapshot, except ordered state that generated
 as DocumentRef will return DocumentSnapshot
 Note: the cache is local and, not persistance. Passing an object from initial
 state or from SSR state will yield undefined.
```

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
https://github.com/prescottprue/redux-firestore/issues/203
