### PR TITLE
feat(core): use extend app to add helpers, fix getFirestore accessor function

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,8 +1,6 @@
 import { defaultConfig } from './constants';
 import createFirestoreInstance from './createFirestoreInstance';
 
-let firestoreInstance;
-
 /**
  * @name reduxFirestore
  * @external
@@ -50,61 +48,12 @@ export default function reduxFirestore(firebaseInstance, otherConfig) {
     const store = next(reducer, initialState, middleware);
 
     const configs = { ...defaultConfig, ...otherConfig };
-    firestoreInstance = createFirestoreInstance(
+    store.firestore = createFirestoreInstance(
       firebaseInstance.firebase_ || firebaseInstance, // eslint-disable-line no-underscore-dangle, no-undef, max-len
       configs,
       store.dispatch, // eslint-disable-line comma-dangle
     );
 
-    store.firestore = firestoreInstance;
-
     return store;
   };
-}
-
-/**
- * Expose Firestore instance created internally. Useful for
- * integrations into external libraries such as redux-thunk and redux-observable.
- * @returns {object} Firebase Instance
- * @example <caption>redux-thunk integration</caption>
- * import { applyMiddleware, compose, createStore } from 'redux';
- * import thunk from 'redux-thunk';
- * import makeRootReducer from './reducers';
- * import { reduxFirestore, getFirestore } from 'redux-firestore';
- *
- * const fbConfig = {} // your firebase config
- *
- * const store = createStore(
- *   makeRootReducer(),
- *   initialState,
- *   compose(
- *     applyMiddleware([
- *       // Pass getFirestore function as extra argument
- *       thunk.withExtraArgument(getFirestore)
- *     ]),
- *     reduxFirestore(fbConfig)
- *   )
- * );
- * // then later
- * export const addTodo = (newTodo) =>
- *  (dispatch, getState, getFirestore) => {
- *    const firebase = getFirestore()
- *    firebase
- *      .add('todos', newTodo)
- *      .then(() => {
- *        dispatch({ type: 'SOME_ACTION' })
- *      })
- * };
- *
- */
-export function getFirestore() {
-  // TODO: Handle recieveing config and creating firebase instance if it doesn't exist
-  /* istanbul ignore next: Firebase instance always exists during tests */
-  if (!firestoreInstance) {
-    throw new Error(
-      'Firebase instance does not yet exist. Check your compose function.',
-    );
-  }
-  // TODO: Create new firebase here with config passed in
-  return firestoreInstance;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import enhancer, { getFirestore } from './enhancer';
+import enhancer from './enhancer';
 import reducer from './reducer';
 import { firestoreActions } from './actions';
-import createFirestoreInstance from './createFirestoreInstance';
+import createFirestoreInstance, { getFirestore } from './createFirestoreInstance';
 import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
 


### PR DESCRIPTION
### Description
- work around frozen firebase object
- fix and move `getFirestore()` to `createFirestoreInstance` so it works when using the new context provider (I think it should still work the old way too, but haven't actually tried it)

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing => nope, broken! If this looks like something that would actually get merged, I can fix 'em
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
#240
