### PR TITLE
fix(query): fix snapshot cache - @illuminist

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -467,7 +467,7 @@ export function orderedFromSnap(snap) {
       const obj = isObject(doc.data())
         ? { id: doc.id, ...(doc.data() || doc.data) }
         : { id: doc.id, data: doc.data() };
-      snapshotCache.set(obj, snap);
+      snapshotCache.set(obj, doc);
       ordered.push(obj);
     });
   }
@@ -492,7 +492,7 @@ export function dataByIdSnapshot(snap) {
   } else if (snap.forEach) {
     snap.forEach(doc => {
       const snapData = doc.data() || doc;
-      snapshotCache.set(snapData, snap);
+      snapshotCache.set(snapData, doc);
       data[doc.id] = snapData;
     });
   }

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -843,7 +843,7 @@ describe('query utils', () => {
     });
   });
 
-  describe.only('snapshotCache', () => {
+  describe('snapshotCache', () => {
     it('retrieve snapshot with data from data state ', () => {
       const id = 'someId';
       const fakeData = { some: 'thing' };

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -843,7 +843,7 @@ describe('query utils', () => {
     });
   });
 
-  describe('dataByIdSnapshot', () => {
+  describe.only('snapshotCache', () => {
     it('retrieve snapshot with data from data state ', () => {
       const id = 'someId';
       const fakeData = { some: 'thing' };
@@ -878,6 +878,7 @@ describe('query utils', () => {
       const fakeSnap = { forEach: docArray.forEach.bind(docArray) };
       result = orderedFromSnap(fakeSnap);
       expect(getSnapshotByObject(result)).to.equal(fakeSnap);
+      expect(getSnapshotByObject(result[0])).to.equal(fakeDocSnap)
     });
   });
 });

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -878,7 +878,7 @@ describe('query utils', () => {
       const fakeSnap = { forEach: docArray.forEach.bind(docArray) };
       result = orderedFromSnap(fakeSnap);
       expect(getSnapshotByObject(result)).to.equal(fakeSnap);
-      expect(getSnapshotByObject(result[0])).to.equal(fakeDocSnap)
+      expect(getSnapshotByObject(result[0])).to.equal(fakeDocSnap);
     });
   });
 });


### PR DESCRIPTION
### Description
I had incorrect data snapshot type for WeakMap value. Have it fixed to be DocumentSnapshot and added the missed test to it.  

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
https://github.com/prescottprue/redux-firestore/issues/257