### PR TITLE
feat(query): support `storeAs` property in `populates` objects in queries - @jfrumar-infinitusai 

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -613,7 +613,11 @@ export function promisesForPopulate(
           getPopulateChild(firebase, p, childDataVal).then(v => {
             // write child to result object under root name if it is found
             if (v) {
-              set(results, `${p.root}.${childDataVal}`, v);
+              set(
+                results,
+                `${p.storeAs ? p.storeAs : p.root}.${childDataVal}`,
+                v,
+              );
             }
           }),
         );
@@ -651,7 +655,11 @@ export function promisesForPopulate(
             getPopulateChild(firebase, p, idOrList).then(v => {
               // write child to result object under root name if it is found
               if (v) {
-                set(results, `${p.root}.${idOrList}`, v);
+                set(
+                  results,
+                  `${p.storeAs ? p.storeAs : p.root}.${idOrList}`,
+                  v,
+                );
               }
               return results;
             }),


### PR DESCRIPTION
### Description

When using the `populates` facility in a query, the `storeAs` property is ignored, and the data that is retrieved is always saved at the root. This means that multiple queries that use the `populates` facility with the same root will fail (subsequent queries will clear out earlier ones).

This small change allows the use of `storeAs` to place the retrieved data in a distinct location.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
