### PR TITLE
chore(docs): add populate example to project page

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -5,15 +5,14 @@
 
 ## Table of Contents
 
-1. [Features](#features)
 1. [Requirements](#requirements)
 1. [Getting Started](#getting-started)
+1. [Understanding the Code](#understanding-the-code)
+1. [Beyond Getting Started](#beyond-getting-started)
+1. [Config Files](#config-files)
 1. [Application Structure](#application-structure)
-1. [Development](#development)
-    1. [Routing](#routing)
-1. [Configuration](#configuration)
-1. [Production](#production)
-1. [Deployment](#deployment)
+1. [Routing](#routing)
+1. [Frequently Asked Questions (FAQ)](#faq)
 
 ## Requirements
 
@@ -22,23 +21,71 @@
 
 ## Getting Started
 
-1. Install app and functions dependencies: `npm i && npm i --prefix functions` or `yarn install && yarn install --cwd functions`
-1. Create `src/config.js` file that looks like so if it does not already exist:
-    ```js
-    const firebase = {
-      // Config from Firebase console
-    }
+The following will take 10-20 minutes to complete.
 
-    // Overrides for for react-redux-firebase/redux-firestore config
-    export const reduxFirebase = {}
+1. Clone the repository: ```git clone https://github.com/prescottprue/redux-firestore```
+1. Go into the working directory for this example: ```cd redux-firestore/example/complete```
+1. Fetch the required npm modules (identified in _package.json_): ```npm install```
+1. In Firebase console, create new project -- for example: _redux-firestore-complete_
+   1. choose default values, nothing special
+   1. add a _web_ app -- for example: _rfc-web_
+   1. copy Firebase SDK's _firebaseConfig_ settings to your clipboard
+1. Edit **config.js**
+   1. Paste (overwrite) the values inside the braces of ```export const firebase { ... }``` with the values from your web app's Firestore SDK settings (previous step).
+   1. Save the file.
+1. In Firebase console for your project, go to Authentication (left sidebar)
+   1. Click the _Sign-in method_ tab
+   1. Enable "Email/Password" (you can keep _Email link_ disabled if you want)
+   1. Click the _Users_ tab
+   1. Click the  **Add user** button
+   1. Enter values that you'll use to authenticate.  The email address does not need to be a real one, though it should be realistic.  I used:
+      * email: **bob@test.com**
+      * password: **pwd123**
+    1. Click **Add user** to save your new user
+1. In Firebase console for your project, go to Database (left sidebar)
+   1. For Cloud Firestore, click **Create database**
+      * _Note_: the UI for Firebase console continues to evolve.  You want to create a _Firestore_ database here, and not a realtime-database.
+   1. Select _Start in test mode_ and click **Next**
+   1. Chooose a location (I went with the default for me -- _nam5 (us-central)_), and click **Next**
+1. In the Firebase console, you should now be back at the Database page and see an empty database with _+ Start collection_ as an option
+1. In your development environment (your computer), start the app with: ```npm start```
+   * I typically do this from the terminal within my VS Code editor.  To start the terminal, I use ```ctrl+` ```
+1. In a browser window (usually one is auto-launched with _npm start_), go to your app.
+   * The default URL is http://localhost:3000/.
+   1. **Login and update your account**
+      1. You should see a page with the title "Home Route".
+      1. Click _Sign In_ (top-right corner of the page)
+      1. Log in with the email & password for the user created above
+      1. You should see an "Account" page.  Feel free to update your account information.  I used:
+         * Display Name: **Bobby McBobface**
+         * Email: **bob@test.com**
+         * Avatar Url: **https://randomuser.me/api/portraits/men/42.jpg**
+      1. Click **Save**
+   1. **Add a new Project**
+      1. Click the _Complete_ title in the top-left corner of the page.  This takes you to the _/projects_ page.
+      1. Click the **+** card in the middle of the page.
+      1. In the _New Project_ dialog, enter a name and click    **CREATE**
+1. In the Firebase console, in the Database page you should now see data in your database -- if not, refresh the page by clicking to another page (e.g. click _Authentication_) and then return to _Database_ ... or simply refresh your browser.
+   * You should now see two collections listed: _projects_ and _users_.
 
-    export default {
-      env,
-      firebase,
-      reduxFirebase
-    }
-    ```
-1. Start Development server: `npm start`
+## Understanding the code
+
+This example project gives an understanding of many aspects of redux-firestore.  Using your favorite editor (e.g. VS Code) browse the codebase looking at how it leverages redux-firestore.
+
+One clear example is in the code for ```ProjectPage``` and its components ```ProjectDetails``` and ```PopulateDetails```.
+
+### ProjectDetails
+
+This component shows how to use ```useFirestoreConnect()```, ```isLoaded()``` and ```useSelector()``` to set a Redux listener to a specific query and display the results.
+
+The query in particular is:
+```[{ collection: 'projects', doc: projectId }]```, meaning we are pulling the document from the _projects_ collection whose ID is the value ```projectId```.  The value of ```projectId``` is passed down to the component from its parent, ```ProjectPage.js``` who in turn gets the value from its associated route defined in ```examples/complete/src/routes/Projects/routes/Project/index.js```
+
+### PopulatedDetails
+
+This component shows how to use ```firestoreConnect()``` and the ```populate()``` method.  The same _projects_ document is retrieved as in the ProjectDetails case (above); additionally the _users_ record is fetched for the associated user who created the given project.
+
+## Beyond Getting Started
 
 While developing, you will probably rely mostly on `npm start`; however, there are additional scripts at your disposal:
 
@@ -155,7 +202,6 @@ export default {
 With this setting, the name of the file (called a "chunk") is defined as part of the code as well as a loading spinner showing while the bundle file is loading.
 
 More about how routing works is available in [the react-router-dom docs](https://reacttraining.com/react-router/web/guides/quick-start).
-
 
 ## FAQ
 

--- a/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.enhancer.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.enhancer.js
@@ -1,0 +1,4 @@
+import { UserIsAuthenticated } from 'utils/router'
+
+// redirect to /login if user is not logged in
+export default UserIsAuthenticated

--- a/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import Typography from '@material-ui/core/Typography'
+
+import { makeStyles } from '@material-ui/core/styles'
+import { useParams } from 'react-router-dom'
+import { connect, useSelector } from 'react-redux'
+import LoadingSpinner from 'components/LoadingSpinner'
+import styles from './PopulatedDetails.styles'
+
+import { firestoreConnect, isLoaded, populate } from 'react-redux-firebase'
+import { compose, } from 'recompose'
+
+
+const useStyles = makeStyles(styles)
+
+function PopulatedDetails() {
+  const { projectId } = useParams()
+  const classes = useStyles()
+
+  // Get projects from redux state
+  const project = useSelector(
+    ({
+      firestore: {
+        data: { projects }
+      }
+    }) => projects && projects[projectId]
+  )
+
+  console.log('PROJECT ', project)
+
+  const creator = useSelector(
+    ({
+      firestore: {
+        data: { users }
+      }
+    }) => users && users[project.createdBy]
+  )
+
+  console.log("CREATOR ", creator)
+
+  // Show loading spinner while project is loading
+  if (!isLoaded(project)) {
+    return <LoadingSpinner />
+  }
+
+  let display =
+    creator && creator.displayName && creator.displayName.length ? (
+      creator.displayName
+    ) : (
+      <em>no display name</em>
+    )
+
+  return (
+    <>
+      <Typography className={classes.title} component="h2">
+        {(project && project.name) || 'Project'}
+      </Typography>
+      <Typography className={classes.subtitle}>{projectId}</Typography>
+      <Typography className={classes.subtitle}>
+        Created by: {display}
+      </Typography>
+      <div style={{ marginTop: '10rem' }}>
+        <pre>{JSON.stringify(project, null, 2)}</pre>
+      </div>
+    </>
+  );
+}
+
+const populates = [{ child: 'createdBy', root: 'users' }]
+const collection = 'projects'
+
+const withPopulatedProjects = compose(
+  firestoreConnect(props => [
+    {
+      collection,
+      populates
+    }
+  ]),
+  connect((state, props) => ({
+    projects: populate(state.firestore, collection, populates)
+  }))
+)
+
+export default withPopulatedProjects(PopulatedDetails)

--- a/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.js
@@ -26,8 +26,6 @@ function PopulatedDetails() {
     }) => projects && projects[projectId]
   )
 
-  console.log('PROJECT ', project)
-
   const creator = useSelector(
     ({
       firestore: {
@@ -35,8 +33,6 @@ function PopulatedDetails() {
       }
     }) => users && users[project.createdBy]
   )
-
-  console.log("CREATOR ", creator)
 
   // Show loading spinner while project is loading
   if (!isLoaded(project)) {

--- a/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.styles.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/PopulatedDetails.styles.js
@@ -1,0 +1,15 @@
+export default theme => ({
+  root: {
+    ...theme.flexColumnCenter,
+    paddingTop: theme.spacing(4),
+    flexGrow: '2',
+    boxSizing: 'border-box',
+    overflowY: 'scroll'
+  },
+  tiles: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    '-webkit-flex-flow': 'row wrap'
+  }
+})

--- a/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/index.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/PopulatedDetails/index.js
@@ -1,0 +1,4 @@
+import PopulatedDetails from './PopulatedDetails'
+import enhance from './PopulatedDetails.enhancer';
+
+export default enhance(PopulatedDetails)

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.enhancer.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.enhancer.js
@@ -1,0 +1,4 @@
+import { UserIsAuthenticated } from 'utils/router'
+
+// redirect to /login if user is not logged in
+export default UserIsAuthenticated

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.js
@@ -14,8 +14,6 @@ function ProjectDetails() {
   const { projectId } = useParams()
   const classes = useStyles()
 
-  console.log("projectId is", projectId)
-  
   // Create listener for projects
   useFirestoreConnect([{ collection: 'projects', doc: projectId }])
 

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import Typography from '@material-ui/core/Typography'
+
+import { makeStyles } from '@material-ui/core/styles'
+import { useParams } from 'react-router-dom'
+import { useFirestoreConnect, isLoaded } from 'react-redux-firebase'
+import { useSelector } from 'react-redux'
+import LoadingSpinner from 'components/LoadingSpinner'
+import styles from './ProjectDetails.styles'
+
+const useStyles = makeStyles(styles)
+
+function ProjectDetails() {
+  const { projectId } = useParams()
+  const classes = useStyles()
+
+  console.log("projectId is", projectId)
+  
+  // Create listener for projects
+  useFirestoreConnect([{ collection: 'projects', doc: projectId }])
+
+  // Get projects from redux state
+  const project = useSelector(
+    ({
+      firestore: {
+        data: { projects }
+      },
+    }) => projects && projects[projectId]
+  )
+
+  // Show loading spinner while project is loading
+  if (!isLoaded(project)) {
+    return <LoadingSpinner />
+  }
+
+  return (
+    <>
+      <Typography className={classes.title} component="h2">
+        {(project && project.name) || 'Project'}
+      </Typography>
+      <Typography className={classes.subtitle}>{projectId}</Typography>
+      <div style={{ marginTop: '10rem' }}>
+        <pre>{JSON.stringify(project, null, 2)}</pre>
+      </div>
+    </>
+  )
+}
+
+export default ProjectDetails

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.styles.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/ProjectDetails.styles.js
@@ -1,0 +1,15 @@
+export default theme => ({
+  root: {
+    ...theme.flexColumnCenter,
+    paddingTop: theme.spacing(4),
+    flexGrow: '2',
+    boxSizing: 'border-box',
+    overflowY: 'scroll'
+  },
+  tiles: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    '-webkit-flex-flow': 'row wrap'
+  }
+})

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/index.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectDetails/index.js
@@ -1,0 +1,4 @@
+import ProjectDetails from './ProjectDetails'
+import enhance from './ProjectDetails.enhancer'
+
+export default enhance(ProjectDetails)

--- a/examples/complete/src/routes/Projects/routes/Project/components/ProjectPage/ProjectPage.js
+++ b/examples/complete/src/routes/Projects/routes/Project/components/ProjectPage/ProjectPage.js
@@ -1,52 +1,63 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
+
+import Box from '@material-ui/core/Box'
 import Card from '@material-ui/core/Card'
 import CardContent from '@material-ui/core/CardContent'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles'
-import { useParams } from 'react-router-dom'
-import { useFirestoreConnect, isLoaded } from 'react-redux-firebase'
-import { useSelector } from 'react-redux'
-import LoadingSpinner from 'components/LoadingSpinner'
 import styles from './ProjectPage.styles'
 
+import ProjectDetails from '../ProjectDetails'
+import PopulatedDetails from '../PopulatedDetails'
+
 const useStyles = makeStyles(styles)
+
+function TabPanel(vals) {
+  const { children, value, index, ...other } = vals
+
+  return (
+    <Typography
+      component="div"
+      role="tabpanel"
+      hidden={value !== index}
+      id={`wrapped-tabpanel-${index}`}
+      aria-labelledby={`wrapped-tab-${index}`}
+      {...other}>
+      {value === index && <Box p={3}>{children}</Box>}
+    </Typography>
+  )
+}
 
 function ProjectPage() {
   const { projectId } = useParams()
   const classes = useStyles()
+  const [value, setValue] = React.useState('standard')
 
-  // Create listener for projects
-  useFirestoreConnect([{ collection: 'projects', doc: projectId }])
-
-  // Get projects from redux state
-  const project = useSelector(
-    ({
-      firestore: {
-        data: { projects }
-      }
-    }) => projects && projects[projectId]
-  )
-
-  // Show loading spinner while project is loading
-  if (!isLoaded(project)) {
-    return <LoadingSpinner />
+  const handleTabChange = (evt, val) => {
+    setValue(val)
   }
 
   return (
     <div className={classes.root}>
       <Card className={classes.card}>
         <CardContent>
-          <Typography className={classes.title} component="h2">
-            {(project && project.name) || 'Project'}
-          </Typography>
-          <Typography className={classes.subtitle}>{projectId}</Typography>
-          <div style={{ marginTop: '10rem' }}>
-            <pre>{JSON.stringify(project, null, 2)}</pre>
-          </div>
+          <Tabs value={value} onChange={handleTabChange}>
+            <Tab value="standard" label="Standard Query" />
+            <Tab value="populated" label="Populated Query" />
+          </Tabs>
+          <TabPanel value={value} index="standard">
+            <ProjectDetails projectId={projectId} />
+          </TabPanel>
+          <TabPanel value={value} index="populated">
+            <PopulatedDetails projectId={projectId} />
+          </TabPanel>
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }
 
 export default ProjectPage


### PR DESCRIPTION
### Description
Update the "complete" example to show both standard useFirestoreConnect() and withPopulatedProjects -- that is, compose(firestoreConnect() + populate())

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
