### PR TITLE
fix(docs): fixing spelling error in storeAs description

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ store.firestore.unsetListeners([query1Options, query2Options]),
 },
 ```
 
-**NOTE**: `storeAs` is now required for subcollections. This is to more closley match the logic of [the upcoming major release (v1)](https://github.com/prescottprue/redux-firestore/wiki/v1.0.0-Roadmap) which stores all collections, even subcollections, at the top level of `data` and `ordered` state slices.
+**NOTE**: `storeAs` is now required for subcollections. This is to more closely match the logic of [the upcoming major release (v1)](https://github.com/prescottprue/redux-firestore/wiki/v1.0.0-Roadmap) which stores all collections, even subcollections, at the top level of `data` and `ordered` state slices.
 
 ##### Collection Group
 


### PR DESCRIPTION
### Description
The word "closley" is incorrect. Changing to "closely"

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
