### PR TITLE
fix(orderedReducer): reorder items when newIndex is zero

### DIFF
--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -58,8 +58,14 @@ function modifyDoc(collectionState, action) {
   // Support moving a doc within an array
   if (action.payload.ordered) {
     const { newIndex, oldIndex } = action.payload.ordered;
-    // newIndex value exists, item was within array before, and the index has changed
-    if (!!newIndex && oldIndex > -1 && newIndex !== oldIndex) {
+    // newIndex/oldIndex values exist, item isn't being removed or added, and the index has changed
+    if (
+      newIndex !== null &&
+      oldIndex !== null &&
+      newIndex > -1 &&
+      oldIndex > -1 &&
+      newIndex !== oldIndex
+    ) {
       return newArrayWithItemMoved(
         collectionState,
         action.meta,


### PR DESCRIPTION
### Description
I came across a bug in the orderedReducer
```
// Support moving a doc within an array
  if (action.payload.ordered) {
    const { newIndex, oldIndex } = action.payload.ordered;
    // newIndex value exists, item was within array before, and the index has changed
    if (!!newIndex && oldIndex > -1 && newIndex !== oldIndex) {
      return newArrayWithItemMoved(
        collectionState,
        action.meta,
        action.payload.ordered,
        action.payload.data,
      );
    }
  }
```
In this expression ` (!!newIndex && oldIndex > -1 && newIndex !== oldIndex)`, if newIndex is equal to zero it will skip reordering the data and just update the document in place. 

In this PR I've updated that expression to something that I think is more robust.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
