### PR TITLE
fix(getFirestore): correctly load extended firestore instance in getFirestore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import enhancer, { getFirestore } from './enhancer';
+import enhancer from './enhancer';
 import reducer from './reducer';
 import { firestoreActions } from './actions';
-import createFirestoreInstance from './createFirestoreInstance';
+import createFirestoreInstance, { getFirestore } from './createFirestoreInstance';
 import constants, { actionTypes } from './constants';
 import middleware, { CALL_FIRESTORE } from './middleware';
 import { getSnapshotByObject } from './utils/query';


### PR DESCRIPTION
### Description

This PR fixes the issues with getFirestore() function not returning the firestore object as mentioned in https://github.com/prescottprue/react-redux-firebase/issues/839#issuecomment-579795781 . To fix it, I've modelled the getFirestore functionality after the getFirebase() function in react-redux-firebase and moved the getFirestore function to createFirestoreInstance. 


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues

https://github.com/prescottprue/react-redux-firebase/issues/785
https://github.com/prescottprue/react-redux-firebase/issues/839
