### PR TITLE
feat(types): required import convention for firebase 8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as Firebase from 'firebase';
+import firebase from 'firebase/app'
 import { Dispatch } from 'redux';
 
 /**


### PR DESCRIPTION
### Description

When Firebase releases v8 they did 3 breaking changes: https://firebase.google.com/support/release-notes/js#version_800_-_october_26_2020

No usage of `experimentalTabSynchronization` or `timestampsInSnapshots ` was found in this codebase.

The old import `import * as firebase from 'firebase/app'` has been replaced by the new import `import firebase from 'firebase/app'`

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues

https://github.com/prescottprue/redux-firestore/issues/312
