### PR TITLE
feat: CLEAR_DATA to clear composite and queries as well

### DIFF
--- a/src/reducers/crossSliceReducer.js
+++ b/src/reducers/crossSliceReducer.js
@@ -2,6 +2,7 @@
 import produce from 'immer';
 import { groupBy, merge, set, get } from 'lodash';
 import { actionTypes } from '../constants';
+import { preserveValuesFromState } from '../utils/reducers';
 
 /**
  * Reducer for crossSlice state
@@ -34,6 +35,12 @@ export default function crossSliceReducer(state = {}, action) {
         });
 
         return draft;
+      case actionTypes.CLEAR_DATA:
+        // support keeping data when logging out - #125
+        if (action.preserve && action.preserve.ordered) {
+          return preserveValuesFromState(state, action.preserve.ordered, {});
+        }
+        return {};
       default:
         return state;
     }

--- a/src/reducers/queriesReducer.js
+++ b/src/reducers/queriesReducer.js
@@ -1,6 +1,7 @@
 import produce from 'immer';
 import { set, get, unset } from 'lodash';
 import { actionTypes } from '../constants';
+import { preserveValuesFromState } from '../utils/reducers';
 import { getBaseQueryName } from '../utils/query';
 
 /**
@@ -49,6 +50,12 @@ export default function queriesReducer(state = {}, action) {
       case actionTypes.DELETE_SUCCESS:
         unset(draft, [key, 'data', action.meta.doc]);
         return draft;
+      case actionTypes.CLEAR_DATA:
+        // support keeping data when logging out - #125
+        if (action.preserve && action.preserve.ordered) {
+          return preserveValuesFromState(state, action.preserve.ordered, {});
+        }
+        return {};
       default:
         return state;
     }


### PR DESCRIPTION
Fixes #418 dispatch({ type: actionTypes.CLEAR_DATA }) does not clear 'queries' and 'composite'
