### PR TITLE
Update index.d.ts (WIP)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -161,7 +161,7 @@ export namespace FirestoreReducer {
   export type OrderedData<Schema extends Record<string, any>> = {
     [T in keyof Schema]: Schema[T] extends Entity<infer V>
       ? EntityWithId<V>[]
-      : OrderedData<EntityWithId<Schema[T]>>[]
+      : EntityWithId<Schema[T]>[]
   }
 
   export interface Reducer<Schema extends Record<string, any> = {}> {


### PR DESCRIPTION
### Description
I believe the type definitions are wrong for the OrderedData generic type. As it is currently, an entity's id is seen to be an array when mapping over an ordered data set. 

I believe that this type is correct (it solves my problem), although I confess I don't fully understand the usage of `infer V` with the schema object.

### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
